### PR TITLE
feat(cnft): add multi asset support

### DIFF
--- a/contracts/AssetWrapper.sol
+++ b/contracts/AssetWrapper.sol
@@ -4,8 +4,12 @@ pragma solidity ^0.8.0;
 import "@openzeppelin/contracts/token/ERC721/ERC721.sol";
 import "@openzeppelin/contracts/token/ERC721/extensions/ERC721Enumerable.sol";
 import "@openzeppelin/contracts/token/ERC721/extensions/ERC721Burnable.sol";
+import "@openzeppelin/contracts/token/ERC721/utils/ERC721Holder.sol";
+import "@openzeppelin/contracts/token/ERC1155/utils/ERC1155Holder.sol";
+import "@openzeppelin/contracts/token/ERC1155/IERC1155.sol";
 import "@openzeppelin/contracts/utils/Context.sol";
 import "@openzeppelin/contracts/utils/Counters.sol";
+import "@openzeppelin/contracts/utils/math/SafeMath.sol";
 import "@uniswap/lib/contracts/libraries/TransferHelper.sol";
 import "./interfaces/IAssetWrapper.sol";
 
@@ -19,8 +23,10 @@ import "./interfaces/IAssetWrapper.sol";
  * At any time, the holder of the bundle NFT can redeem it for the
  * underlying assets.
  */
-contract AssetWrapper is Context, ERC721Enumerable, ERC721Burnable, IAssetWrapper {
+contract AssetWrapper is Context, ERC721Enumerable, ERC721Burnable, ERC1155Holder, ERC721Holder, IAssetWrapper {
     using Counters for Counters.Counter;
+    using SafeMath for uint256;
+
     Counters.Counter private _tokenIdTracker;
 
     struct ERC20Holding {
@@ -28,6 +34,21 @@ contract AssetWrapper is Context, ERC721Enumerable, ERC721Burnable, IAssetWrappe
         uint256 amount;
     }
     mapping(uint256 => ERC20Holding[]) public bundleERC20Holdings;
+
+    struct ERC721Holding {
+        address tokenAddress;
+        uint256 tokenId;
+    }
+    mapping(uint256 => ERC721Holding[]) public bundleERC721Holdings;
+
+    struct ERC1155Holding {
+        address tokenAddress;
+        uint256 tokenId;
+        uint256 amount;
+    }
+    mapping(uint256 => ERC1155Holding[]) public bundleERC1155Holdings;
+
+    mapping(uint256 => uint256) public bundleETHHoldings;
 
     /**
      * @dev Initializes the token with name and symbol parameters
@@ -50,13 +71,60 @@ contract AssetWrapper is Context, ERC721Enumerable, ERC721Burnable, IAssetWrappe
         uint256 amount,
         uint256 bundleId
     ) external override {
+        require(_exists(bundleId), "Bundle does not exist");
+
         TransferHelper.safeTransferFrom(tokenAddress, _msgSender(), address(this), amount);
 
         // Note: there can be multiple `ERC20Holding` objects for the same token contract
         // in a given bundle. We could deduplicate them here, though I don't think
         // it's worth the extra complexity - the end effect is the same in either case.
         bundleERC20Holdings[bundleId].push(ERC20Holding(tokenAddress, amount));
-        emit DepositERC20(tokenAddress, amount, bundleId);
+        emit DepositERC20(_msgSender(), bundleId, tokenAddress, amount);
+    }
+
+    /**
+     * @inheritdoc IAssetWrapper
+     */
+    function depositERC721(
+        address tokenAddress,
+        uint256 tokenId,
+        uint256 bundleId
+    ) external override {
+        require(_exists(bundleId), "Bundle does not exist");
+
+        IERC721(tokenAddress).transferFrom(_msgSender(), address(this), tokenId);
+
+        bundleERC721Holdings[bundleId].push(ERC721Holding(tokenAddress, tokenId));
+        emit DepositERC721(_msgSender(), bundleId, tokenAddress, tokenId);
+    }
+
+    /**
+     * @inheritdoc IAssetWrapper
+     */
+    function depositERC1155(
+        address tokenAddress,
+        uint256 tokenId,
+        uint256 amount,
+        uint256 bundleId
+    ) external override {
+        require(_exists(bundleId), "Bundle does not exist");
+
+        IERC1155(tokenAddress).safeTransferFrom(_msgSender(), address(this), tokenId, amount, "");
+
+        bundleERC1155Holdings[bundleId].push(ERC1155Holding(tokenAddress, tokenId, amount));
+        emit DepositERC1155(_msgSender(), bundleId, tokenAddress, tokenId, amount);
+    }
+
+    /**
+     * @inheritdoc IAssetWrapper
+     */
+    function depositETH(uint256 bundleId) external payable override {
+        require(_exists(bundleId), "Bundle does not exist");
+
+        uint256 amount = msg.value;
+
+        bundleETHHoldings[bundleId] = bundleETHHoldings[bundleId].add(amount);
+        emit DepositETH(_msgSender(), bundleId, amount);
     }
 
     /**
@@ -66,11 +134,41 @@ contract AssetWrapper is Context, ERC721Enumerable, ERC721Burnable, IAssetWrappe
         require(_isApprovedOrOwner(_msgSender(), bundleId), "AssetWrapper: Non-owner withdrawal");
         burn(bundleId);
 
-        ERC20Holding[] memory holdings = bundleERC20Holdings[bundleId];
-        for (uint256 i = 0; i < holdings.length; i++) {
-            TransferHelper.safeTransfer(holdings[i].tokenAddress, _msgSender(), holdings[i].amount);
+        ERC20Holding[] memory erc20Holdings = bundleERC20Holdings[bundleId];
+        for (uint256 i = 0; i < erc20Holdings.length; i++) {
+            TransferHelper.safeTransfer(erc20Holdings[i].tokenAddress, _msgSender(), erc20Holdings[i].amount);
         }
         delete bundleERC20Holdings[bundleId];
+
+        ERC721Holding[] memory erc721Holdings = bundleERC721Holdings[bundleId];
+        for (uint256 i = 0; i < erc721Holdings.length; i++) {
+            IERC721(erc721Holdings[i].tokenAddress).safeTransferFrom(
+                address(this),
+                _msgSender(),
+                erc721Holdings[i].tokenId
+            );
+        }
+        delete bundleERC721Holdings[bundleId];
+
+        ERC1155Holding[] memory erc1155Holdings = bundleERC1155Holdings[bundleId];
+        for (uint256 i = 0; i < erc1155Holdings.length; i++) {
+            IERC1155(erc1155Holdings[i].tokenAddress).safeTransferFrom(
+                address(this),
+                _msgSender(),
+                erc1155Holdings[i].tokenId,
+                erc1155Holdings[i].amount,
+                ""
+            );
+        }
+        delete bundleERC1155Holdings[bundleId];
+
+        uint256 ethHoldings = bundleETHHoldings[bundleId];
+        // solhint-disable-next-line avoid-low-level-calls
+        (bool success, ) = _msgSender().call{ value: ethHoldings }("");
+        require(success, "Failed to withdraw ETH");
+        delete bundleETHHoldings[bundleId];
+
+        emit Withdraw(_msgSender(), bundleId);
     }
 
     /**
@@ -91,7 +189,7 @@ contract AssetWrapper is Context, ERC721Enumerable, ERC721Burnable, IAssetWrappe
         public
         view
         virtual
-        override(ERC721, ERC721Enumerable)
+        override(ERC721, ERC721Enumerable, ERC1155Receiver)
         returns (bool)
     {
         return super.supportsInterface(interfaceId);

--- a/contracts/interfaces/IAssetWrapper.sol
+++ b/contracts/interfaces/IAssetWrapper.sol
@@ -9,7 +9,33 @@ interface IAssetWrapper {
     /**
      * @dev Emitted when an ERC20 token is deposited
      */
-    event DepositERC20(address indexed tokenAddress, uint256 indexed amount, uint256 indexed bundleId);
+    event DepositERC20(address indexed depositor, uint256 indexed bundleId, address tokenAddress, uint256 amount);
+
+    /**
+     * @dev Emitted when an ERC721 token is deposited
+     */
+    event DepositERC721(address indexed depositor, uint256 indexed bundleId, address tokenAddress, uint256 tokenId);
+
+    /**
+     * @dev Emitted when an ERC1155 token is deposited
+     */
+    event DepositERC1155(
+        address indexed depositor,
+        uint256 indexed bundleId,
+        address tokenAddress,
+        uint256 tokenId,
+        uint256 amount
+    );
+
+    /**
+     * @dev Emitted when ETH is deposited
+     */
+    event DepositETH(address indexed depositor, uint256 indexed bundleId, uint256 amount);
+
+    /**
+     * @dev Emitted when ETH is deposited
+     */
+    event Withdraw(address indexed withdrawer, uint256 indexed bundleId);
 
     /**
      * @dev Creates a new bundle token for `to`. Its token ID will be
@@ -32,6 +58,44 @@ interface IAssetWrapper {
         uint256 amount,
         uint256 bundleId
     ) external;
+
+    /**
+     * @dev Deposit an ERC721 token into a given bundle
+     *
+     * Requirements:
+     *
+     * - The bundle with id `bundleId` must have been initialized with {initializeBundle}
+     * - The `tokenId` NFT from `msg.sender` on `tokenAddress` must have been approved to this contract
+     */
+    function depositERC721(
+        address tokenAddress,
+        uint256 tokenId,
+        uint256 bundleId
+    ) external;
+
+    /**
+     * @dev Deposit an ERC1155 token into a given bundle
+     *
+     * Requirements:
+     *
+     * - The bundle with id `bundleId` must have been initialized with {initializeBundle}
+     * - The `tokenId` from `msg.sender` on `tokenAddress` must have been approved for at least `amount`to this contract
+     */
+    function depositERC1155(
+        address tokenAddress,
+        uint256 tokenId,
+        uint256 amount,
+        uint256 bundleId
+    ) external;
+
+    /**
+     * @dev Deposit some ETH into a given bundle
+     *
+     * Requirements:
+     *
+     * - The bundle with id `bundleId` must have been initialized with {initializeBundle}
+     */
+    function depositETH(uint256 bundleId) external payable;
 
     /**
      * @dev Withdraw all assets in the given bundle, returning them to the msg.sender

--- a/contracts/test/MockERC1155.sol
+++ b/contracts/test/MockERC1155.sol
@@ -1,0 +1,32 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+import "@openzeppelin/contracts/utils/Context.sol";
+import "@openzeppelin/contracts/token/ERC1155/ERC1155.sol";
+import "@openzeppelin/contracts/utils/Counters.sol";
+
+contract MockERC1155 is Context, ERC1155 {
+    using Counters for Counters.Counter;
+    Counters.Counter private _tokenIdTracker;
+
+    /**
+     * @dev Initializes ERC1155 token
+     */
+    constructor() ERC1155("") {}
+
+    /**
+     * @dev Creates `amount` tokens of token type `id`, and assigns them to `account`.
+     *
+     * Emits a {TransferSingle} event.
+     *
+     * Requirements:
+     *
+     * - `account` cannot be the zero address.
+     * - If `account` refers to a smart contract, it must implement {IERC1155Receiver-onERC1155Received} and return the
+     * acceptance magic value.
+     */
+    function mint(address to, uint256 amount) public virtual {
+        _mint(to, _tokenIdTracker.current(), amount, "");
+        _tokenIdTracker.increment();
+    }
+}

--- a/contracts/test/MockERC721.sol
+++ b/contracts/test/MockERC721.sol
@@ -1,0 +1,26 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+import "@openzeppelin/contracts/utils/Context.sol";
+import "@openzeppelin/contracts/token/ERC721/extensions/ERC721Enumerable.sol";
+import "@openzeppelin/contracts/utils/Counters.sol";
+
+contract MockERC721 is Context, ERC721Enumerable {
+    using Counters for Counters.Counter;
+    Counters.Counter private _tokenIdTracker;
+
+    /**
+     * @dev Initializes ERC721 token
+     */
+    constructor(string memory name, string memory symbol) ERC721(name, symbol) {}
+
+    /**
+     * @dev Creates `amount` new tokens for `to`. Public for any test to call.
+     *
+     * See {ERC721-_mint}.
+     */
+    function mint(address to) public virtual {
+        _mint(to, _tokenIdTracker.current());
+        _tokenIdTracker.increment();
+    }
+}

--- a/test/AssetWrapper.ts
+++ b/test/AssetWrapper.ts
@@ -2,9 +2,10 @@ import { expect } from "chai";
 import hre from "hardhat";
 import { BigNumber, Signer } from "ethers";
 
-import { AssetWrapper } from "../typechain/AssetWrapper";
-import { MockERC20 } from "../typechain/MockERC20";
+import { AssetWrapper, MockERC20, MockERC721, MockERC1155 } from "../typechain";
 import { approve, mint, ZERO_ADDRESS } from "./utils/erc20";
+import { approve as approveERC721, mint as mintERC721 } from "./utils/erc721";
+import { approve as approveERC1155, mint as mintERC1155 } from "./utils/erc1155";
 import { deploy } from "./utils/contracts";
 
 const ZERO = hre.ethers.utils.parseUnits("0", 18);
@@ -12,6 +13,8 @@ const ZERO = hre.ethers.utils.parseUnits("0", 18);
 interface TestContext {
   assetWrapper: AssetWrapper;
   mockERC20: MockERC20;
+  mockERC721: MockERC721;
+  mockERC1155: MockERC1155;
   user: Signer;
   other: Signer;
   signers: Signer[];
@@ -26,8 +29,18 @@ describe("AssetWrapper", () => {
 
     const assetWrapper = <AssetWrapper>await deploy("AssetWrapper", signers[0], ["AssetWrapper", "WRP"]);
     const mockERC20 = <MockERC20>await deploy("MockERC20", signers[0], ["Mock ERC20", "MOCK"]);
+    const mockERC721 = <MockERC721>await deploy("MockERC721", signers[0], ["Mock ERC721", "MOCK"]);
+    const mockERC1155 = <MockERC1155>await deploy("MockERC1155", signers[0], []);
 
-    return { assetWrapper, mockERC20, user: signers[0], other: signers[1], signers: signers.slice(2) };
+    return {
+      assetWrapper,
+      mockERC20,
+      mockERC721,
+      mockERC1155,
+      user: signers[0],
+      other: signers[1],
+      signers: signers.slice(2),
+    };
   };
 
   /**
@@ -70,153 +83,763 @@ describe("AssetWrapper", () => {
   });
 
   describe("Deposit", () => {
-    it("should accept deposit from an ERC20 token", async () => {
-      const { assetWrapper, mockERC20, user } = await setupTestContext();
-      const amount = hre.ethers.utils.parseUnits("50", 18);
-
-      await mint(mockERC20, user, amount);
-      await approve(mockERC20, user, assetWrapper.address, amount);
-
-      const bundleId = await initializeBundle(assetWrapper, user);
-
-      await expect(assetWrapper.connect(user).depositERC20(mockERC20.address, amount, bundleId))
-        .to.emit(mockERC20, "Transfer")
-        .withArgs(await user.getAddress(), assetWrapper.address, amount)
-        .to.emit(assetWrapper, "DepositERC20")
-        .withArgs(mockERC20.address, amount, bundleId);
-
-      const holdingsData = await assetWrapper.bundleERC20Holdings(bundleId, 0);
-      expect(holdingsData.tokenAddress).to.equal(mockERC20.address);
-      expect(holdingsData.amount).to.equal(amount);
-    });
-
-    it("should throw when not approved", async () => {
-      const { assetWrapper, mockERC20, user } = await setupTestContext();
-      const amount = hre.ethers.utils.parseUnits("50", 18);
-
-      await mint(mockERC20, user, amount);
-
-      const bundleId = await initializeBundle(assetWrapper, user);
-
-      await expect(assetWrapper.connect(user).depositERC20(mockERC20.address, amount, bundleId)).to.be.reverted;
-    });
-
-    it("should throw when depositing more than owned", async () => {
-      const { assetWrapper, mockERC20, user } = await setupTestContext();
-      const amount = hre.ethers.utils.parseUnits("50", 18);
-
-      await mint(mockERC20, user, amount);
-      await approve(mockERC20, user, assetWrapper.address, amount);
-
-      const bundleId = await initializeBundle(assetWrapper, user);
-
-      await expect(assetWrapper.connect(user).depositERC20(mockERC20.address, amount.mul(2), bundleId)).to.be.reverted;
-    });
-
-    it("should accept multiple deposits from an ERC20 token", async () => {
-      const { assetWrapper, mockERC20, user } = await setupTestContext();
-      const bundleId = await initializeBundle(assetWrapper, user);
-      const baseAmount = hre.ethers.utils.parseUnits("10", 18);
-
-      await approve(mockERC20, user, assetWrapper.address, hre.ethers.constants.MaxUint256);
-
-      for (let i = 0; i < 10; i++) {
-        const amount = baseAmount.mul(i);
-        await mint(mockERC20, user, amount);
-
-        await expect(assetWrapper.connect(user).depositERC20(mockERC20.address, amount, bundleId))
-          .to.emit(mockERC20, "Transfer")
-          .withArgs(await user.getAddress(), assetWrapper.address, amount)
-          .to.emit(assetWrapper, "DepositERC20")
-          .withArgs(mockERC20.address, amount, bundleId);
-
-        const holdingsData = await assetWrapper.bundleERC20Holdings(bundleId, i);
-        expect(holdingsData.tokenAddress).to.equal(mockERC20.address);
-        expect(holdingsData.amount).to.equal(amount);
-      }
-    });
-
-    it("should accept deposits from multiple ERC20 tokens", async () => {
-      const { assetWrapper, user } = await setupTestContext();
-      const bundleId = await initializeBundle(assetWrapper, user);
-      const baseAmount = hre.ethers.utils.parseUnits("10", 18);
-
-      for (let i = 0; i < 10; i++) {
-        const mockERC20 = <MockERC20>await deploy("MockERC20", user, ["Mock ERC20", "MOCK" + i]);
-        const amount = baseAmount.mul(i);
+    describe("ERC20", () => {
+      it("should accept deposit from an ERC20 token", async () => {
+        const { assetWrapper, mockERC20, user } = await setupTestContext();
+        const amount = hre.ethers.utils.parseUnits("50", 18);
 
         await mint(mockERC20, user, amount);
         await approve(mockERC20, user, assetWrapper.address, amount);
 
+        const bundleId = await initializeBundle(assetWrapper, user);
+
         await expect(assetWrapper.connect(user).depositERC20(mockERC20.address, amount, bundleId))
           .to.emit(mockERC20, "Transfer")
           .withArgs(await user.getAddress(), assetWrapper.address, amount)
           .to.emit(assetWrapper, "DepositERC20")
-          .withArgs(mockERC20.address, amount, bundleId);
+          .withArgs(await user.getAddress(), bundleId, mockERC20.address, amount);
 
-        const holdingsData = await assetWrapper.bundleERC20Holdings(bundleId, i);
+        const holdingsData = await assetWrapper.bundleERC20Holdings(bundleId, 0);
         expect(holdingsData.tokenAddress).to.equal(mockERC20.address);
         expect(holdingsData.amount).to.equal(amount);
-      }
+      });
+
+      it("should throw when depositing into uninitialized bundle", async () => {
+        const { assetWrapper, mockERC20, user } = await setupTestContext();
+        const amount = hre.ethers.utils.parseUnits("50", 18);
+
+        const bundleId = BigNumber.from("1005432");
+
+        await expect(assetWrapper.connect(user).depositERC20(mockERC20.address, amount, bundleId)).to.be.revertedWith(
+          "Bundle does not exist",
+        );
+      });
+
+      it("should throw when not approved", async () => {
+        const { assetWrapper, mockERC20, user } = await setupTestContext();
+        const amount = hre.ethers.utils.parseUnits("50", 18);
+
+        await mint(mockERC20, user, amount);
+
+        const bundleId = await initializeBundle(assetWrapper, user);
+
+        await expect(assetWrapper.connect(user).depositERC20(mockERC20.address, amount, bundleId)).to.be.revertedWith(
+          "TransferHelper::transferFrom: transferFrom failed",
+        );
+      });
+
+      it("should throw when depositing more than owned", async () => {
+        const { assetWrapper, mockERC20, user } = await setupTestContext();
+        const amount = hre.ethers.utils.parseUnits("50", 18);
+
+        await mint(mockERC20, user, amount);
+        await approve(mockERC20, user, assetWrapper.address, amount);
+
+        const bundleId = await initializeBundle(assetWrapper, user);
+
+        await expect(
+          assetWrapper.connect(user).depositERC20(mockERC20.address, amount.mul(2), bundleId),
+        ).to.be.revertedWith("TransferHelper::transferFrom: transferFrom failed");
+      });
+
+      it("should accept multiple deposits from an ERC20 token", async () => {
+        const { assetWrapper, mockERC20, user } = await setupTestContext();
+        const bundleId = await initializeBundle(assetWrapper, user);
+        const baseAmount = hre.ethers.utils.parseUnits("10", 18);
+
+        await approve(mockERC20, user, assetWrapper.address, hre.ethers.constants.MaxUint256);
+
+        for (let i = 0; i < 10; i++) {
+          const amount = baseAmount.mul(i);
+          await mint(mockERC20, user, amount);
+
+          await expect(assetWrapper.connect(user).depositERC20(mockERC20.address, amount, bundleId))
+            .to.emit(mockERC20, "Transfer")
+            .withArgs(await user.getAddress(), assetWrapper.address, amount)
+            .to.emit(assetWrapper, "DepositERC20")
+            .withArgs(await user.getAddress(), bundleId, mockERC20.address, amount);
+
+          const holdingsData = await assetWrapper.bundleERC20Holdings(bundleId, i);
+          expect(holdingsData.tokenAddress).to.equal(mockERC20.address);
+          expect(holdingsData.amount).to.equal(amount);
+        }
+      });
+
+      it("should accept deposits from multiple ERC20 tokens", async () => {
+        const { assetWrapper, user } = await setupTestContext();
+        const bundleId = await initializeBundle(assetWrapper, user);
+        const baseAmount = hre.ethers.utils.parseUnits("10", 18);
+
+        for (let i = 0; i < 10; i++) {
+          const mockERC20 = <MockERC20>await deploy("MockERC20", user, ["Mock ERC20", "MOCK" + i]);
+          const amount = baseAmount.mul(i);
+
+          await mint(mockERC20, user, amount);
+          await approve(mockERC20, user, assetWrapper.address, amount);
+
+          await expect(assetWrapper.connect(user).depositERC20(mockERC20.address, amount, bundleId))
+            .to.emit(mockERC20, "Transfer")
+            .withArgs(await user.getAddress(), assetWrapper.address, amount)
+            .to.emit(assetWrapper, "DepositERC20")
+            .withArgs(await user.getAddress(), bundleId, mockERC20.address, amount);
+
+          const holdingsData = await assetWrapper.bundleERC20Holdings(bundleId, i);
+          expect(holdingsData.tokenAddress).to.equal(mockERC20.address);
+          expect(holdingsData.amount).to.equal(amount);
+        }
+      });
+    });
+
+    describe("ERC721", () => {
+      it("should accept deposit from an ERC721 token", async () => {
+        const { assetWrapper, mockERC721, user } = await setupTestContext();
+
+        const tokenId = await mintERC721(mockERC721, user);
+        await approveERC721(mockERC721, user, assetWrapper.address, tokenId);
+
+        const bundleId = await initializeBundle(assetWrapper, user);
+
+        await expect(assetWrapper.connect(user).depositERC721(mockERC721.address, tokenId, bundleId))
+          .to.emit(mockERC721, "Transfer")
+          .withArgs(await user.getAddress(), assetWrapper.address, tokenId)
+          .to.emit(assetWrapper, "DepositERC721")
+          .withArgs(await user.getAddress(), bundleId, mockERC721.address, tokenId);
+
+        const holdingsData = await assetWrapper.bundleERC721Holdings(bundleId, 0);
+        expect(holdingsData.tokenAddress).to.equal(mockERC721.address);
+        expect(holdingsData.tokenId).to.equal(tokenId);
+      });
+
+      it("should throw when depositing into uninitialized bundle", async () => {
+        const { assetWrapper, mockERC721, user } = await setupTestContext();
+
+        const tokenId = await mintERC721(mockERC721, user);
+        const bundleId = BigNumber.from("1005432");
+
+        await expect(
+          assetWrapper.connect(user).depositERC721(mockERC721.address, tokenId, bundleId),
+        ).to.be.revertedWith("Bundle does not exist");
+      });
+
+      it("should throw when not approved", async () => {
+        const { assetWrapper, mockERC721, user } = await setupTestContext();
+
+        const tokenId = await mintERC721(mockERC721, user);
+        const bundleId = await initializeBundle(assetWrapper, user);
+
+        await expect(
+          assetWrapper.connect(user).depositERC721(mockERC721.address, tokenId, bundleId),
+        ).to.be.revertedWith("ERC721: transfer caller is not owner nor approved");
+      });
+
+      it("should accept multiple deposits from an ERC721 token", async () => {
+        const { assetWrapper, mockERC721, user } = await setupTestContext();
+        const bundleId = await initializeBundle(assetWrapper, user);
+
+        for (let i = 0; i < 10; i++) {
+          const tokenId = await mintERC721(mockERC721, user);
+          await approveERC721(mockERC721, user, assetWrapper.address, tokenId);
+
+          await expect(assetWrapper.connect(user).depositERC721(mockERC721.address, tokenId, bundleId))
+            .to.emit(mockERC721, "Transfer")
+            .withArgs(await user.getAddress(), assetWrapper.address, tokenId)
+            .to.emit(assetWrapper, "DepositERC721")
+            .withArgs(await user.getAddress(), bundleId, mockERC721.address, tokenId);
+
+          const holdingsData = await assetWrapper.bundleERC721Holdings(bundleId, i);
+          expect(holdingsData.tokenAddress).to.equal(mockERC721.address);
+          expect(holdingsData.tokenId).to.equal(tokenId);
+        }
+      });
+
+      it("should accept multiple deposits from an ERC721 token with setApprovalForAll", async () => {
+        const { assetWrapper, mockERC721, user } = await setupTestContext();
+        const bundleId = await initializeBundle(assetWrapper, user);
+
+        const tokenIds = [];
+        for (let i = 0; i < 10; i++) {
+          const tokenId = await mintERC721(mockERC721, user);
+          tokenIds.push(tokenId);
+        }
+
+        await mockERC721.connect(user).setApprovalForAll(assetWrapper.address, true);
+
+        for (let i = 0; i < 10; i++) {
+          const tokenId = tokenIds[i];
+          await expect(assetWrapper.connect(user).depositERC721(mockERC721.address, tokenId, bundleId))
+            .to.emit(mockERC721, "Transfer")
+            .withArgs(await user.getAddress(), assetWrapper.address, tokenId)
+            .to.emit(assetWrapper, "DepositERC721")
+            .withArgs(await user.getAddress(), bundleId, mockERC721.address, tokenId);
+
+          const holdingsData = await assetWrapper.bundleERC721Holdings(bundleId, i);
+          expect(holdingsData.tokenAddress).to.equal(mockERC721.address);
+          expect(holdingsData.tokenId).to.equal(tokenId);
+        }
+      });
+
+      it("should accept deposits from multiple ERC721 tokens", async () => {
+        const { assetWrapper, user } = await setupTestContext();
+        const bundleId = await initializeBundle(assetWrapper, user);
+
+        for (let i = 0; i < 10; i++) {
+          const mockERC721 = <MockERC721>await deploy("MockERC721", user, ["Mock ERC721", "MOCK" + i]);
+
+          const tokenId = await mintERC721(mockERC721, user);
+          await approveERC721(mockERC721, user, assetWrapper.address, tokenId);
+
+          await expect(assetWrapper.connect(user).depositERC721(mockERC721.address, tokenId, bundleId))
+            .to.emit(mockERC721, "Transfer")
+            .withArgs(await user.getAddress(), assetWrapper.address, tokenId)
+            .to.emit(assetWrapper, "DepositERC721")
+            .withArgs(await user.getAddress(), bundleId, mockERC721.address, tokenId);
+
+          const holdingsData = await assetWrapper.bundleERC721Holdings(bundleId, i);
+          expect(holdingsData.tokenAddress).to.equal(mockERC721.address);
+          expect(holdingsData.tokenId).to.equal(tokenId);
+        }
+      });
+    });
+
+    describe("ERC1155", () => {
+      it("should accept deposit from an ERC1155 NFT", async () => {
+        const { assetWrapper, mockERC1155, user } = await setupTestContext();
+        const amount = BigNumber.from("1");
+
+        const tokenId = await mintERC1155(mockERC1155, user, amount);
+        await approveERC1155(mockERC1155, user, assetWrapper.address);
+
+        const bundleId = await initializeBundle(assetWrapper, user);
+
+        await expect(assetWrapper.connect(user).depositERC1155(mockERC1155.address, tokenId, amount, bundleId))
+          .to.emit(mockERC1155, "TransferSingle")
+          .withArgs(assetWrapper.address, await user.getAddress(), assetWrapper.address, tokenId, amount)
+          .to.emit(assetWrapper, "DepositERC1155")
+          .withArgs(await user.getAddress(), bundleId, mockERC1155.address, tokenId, amount);
+
+        const holdingsData = await assetWrapper.bundleERC1155Holdings(bundleId, 0);
+        expect(holdingsData.tokenAddress).to.equal(mockERC1155.address);
+        expect(holdingsData.tokenId).to.equal(tokenId);
+        expect(holdingsData.amount).to.equal(amount);
+      });
+
+      it("should accept deposit from an ERC1155 fungible token", async () => {
+        const { assetWrapper, mockERC1155, user } = await setupTestContext();
+        const amount = hre.ethers.utils.parseEther("10");
+
+        const tokenId = await mintERC1155(mockERC1155, user, amount);
+        await approveERC1155(mockERC1155, user, assetWrapper.address);
+
+        const bundleId = await initializeBundle(assetWrapper, user);
+
+        await expect(assetWrapper.connect(user).depositERC1155(mockERC1155.address, tokenId, amount, bundleId))
+          .to.emit(mockERC1155, "TransferSingle")
+          .withArgs(assetWrapper.address, await user.getAddress(), assetWrapper.address, tokenId, amount)
+          .to.emit(assetWrapper, "DepositERC1155")
+          .withArgs(await user.getAddress(), bundleId, mockERC1155.address, tokenId, amount);
+
+        const holdingsData = await assetWrapper.bundleERC1155Holdings(bundleId, 0);
+        expect(holdingsData.tokenAddress).to.equal(mockERC1155.address);
+        expect(holdingsData.tokenId).to.equal(tokenId);
+        expect(holdingsData.amount).to.equal(amount);
+      });
+
+      it("should throw when depositing into uninitialized bundle", async () => {
+        const { assetWrapper, mockERC1155, user } = await setupTestContext();
+        const amount = BigNumber.from("1");
+
+        const tokenId = await mintERC1155(mockERC1155, user, amount);
+        const bundleId = BigNumber.from("1005432");
+
+        await expect(
+          assetWrapper.connect(user).depositERC1155(mockERC1155.address, tokenId, amount, bundleId),
+        ).to.be.revertedWith("Bundle does not exist");
+      });
+
+      it("should throw when not approved", async () => {
+        const { assetWrapper, mockERC1155, user } = await setupTestContext();
+        const amount = BigNumber.from("1");
+
+        const tokenId = await mintERC1155(mockERC1155, user, amount);
+        const bundleId = await initializeBundle(assetWrapper, user);
+
+        await expect(
+          assetWrapper.connect(user).depositERC1155(mockERC1155.address, tokenId, amount, bundleId),
+        ).to.be.revertedWith("ERC1155: caller is not owner nor approved");
+      });
+
+      it("should accept multiple deposits from an ERC1155 token", async () => {
+        const { assetWrapper, mockERC1155, user } = await setupTestContext();
+        const bundleId = await initializeBundle(assetWrapper, user);
+        const amount = BigNumber.from("1");
+
+        for (let i = 0; i < 10; i++) {
+          const tokenId = await mintERC1155(mockERC1155, user, amount);
+          await approveERC1155(mockERC1155, user, assetWrapper.address);
+
+          await expect(assetWrapper.connect(user).depositERC1155(mockERC1155.address, tokenId, amount, bundleId))
+            .to.emit(mockERC1155, "TransferSingle")
+            .withArgs(assetWrapper.address, await user.getAddress(), assetWrapper.address, tokenId, amount)
+            .to.emit(assetWrapper, "DepositERC1155")
+            .withArgs(await user.getAddress(), bundleId, mockERC1155.address, tokenId, amount);
+
+          const holdingsData = await assetWrapper.bundleERC1155Holdings(bundleId, i);
+          expect(holdingsData.tokenAddress).to.equal(mockERC1155.address);
+          expect(holdingsData.tokenId).to.equal(tokenId);
+          expect(holdingsData.amount).to.equal(amount);
+        }
+      });
+
+      it("should accept deposits from multiple ERC1155 tokens", async () => {
+        const { assetWrapper, user } = await setupTestContext();
+        const bundleId = await initializeBundle(assetWrapper, user);
+        const amount = BigNumber.from("1");
+
+        for (let i = 0; i < 10; i++) {
+          const mockERC1155 = <MockERC1155>await deploy("MockERC1155", user, []);
+
+          const tokenId = await mintERC1155(mockERC1155, user, amount);
+          await approveERC1155(mockERC1155, user, assetWrapper.address);
+
+          await expect(assetWrapper.connect(user).depositERC1155(mockERC1155.address, tokenId, amount, bundleId))
+            .to.emit(mockERC1155, "TransferSingle")
+            .withArgs(assetWrapper.address, await user.getAddress(), assetWrapper.address, tokenId, amount)
+            .to.emit(assetWrapper, "DepositERC1155")
+            .withArgs(await user.getAddress(), bundleId, mockERC1155.address, tokenId, amount);
+
+          const holdingsData = await assetWrapper.bundleERC1155Holdings(bundleId, i);
+          expect(holdingsData.tokenAddress).to.equal(mockERC1155.address);
+          expect(holdingsData.tokenId).to.equal(tokenId);
+          expect(holdingsData.amount).to.equal(amount);
+        }
+      });
+    });
+
+    describe("ETH", () => {
+      it("should accept deposit of ETH", async () => {
+        const { assetWrapper, user } = await setupTestContext();
+        const amount = hre.ethers.utils.parseEther("50");
+
+        const bundleId = await initializeBundle(assetWrapper, user);
+
+        await expect(assetWrapper.connect(user).depositETH(bundleId, { value: amount }))
+          .to.emit(assetWrapper, "DepositETH")
+          .withArgs(await user.getAddress(), bundleId, amount);
+
+        const holdings = await assetWrapper.bundleETHHoldings(bundleId);
+        expect(holdings).to.equal(amount);
+      });
+
+      it("should accept multiple deposits of ETH", async () => {
+        const { assetWrapper, user } = await setupTestContext();
+        const bundleId = await initializeBundle(assetWrapper, user);
+
+        let total = BigNumber.from(0);
+        for (let i = 1; i <= 10; i++) {
+          const amount = hre.ethers.utils.parseEther(i.toString());
+          await expect(assetWrapper.connect(user).depositETH(bundleId, { value: amount }))
+            .to.emit(assetWrapper, "DepositETH")
+            .withArgs(await user.getAddress(), bundleId, amount);
+          total = total.add(amount);
+        }
+
+        const holdings = await assetWrapper.bundleETHHoldings(bundleId);
+        expect(holdings).to.equal(total);
+      });
+
+      it("should throw when depositing into uninitialized bundle", async () => {
+        const { assetWrapper, user } = await setupTestContext();
+        const amount = hre.ethers.utils.parseEther("50");
+
+        const bundleId = BigNumber.from("1005432");
+
+        await expect(assetWrapper.connect(user).depositETH(bundleId, { value: amount })).to.be.revertedWith(
+          "Bundle does not exist",
+        );
+      });
     });
   });
 
   describe("Withdraw", () => {
-    /**
-     * Set up a withdrawal test by depositing some ERC20s into a bundle
-     */
-    const initializeAndDeposit = async (
-      token: MockERC20,
-      assetWrapper: AssetWrapper,
-      amount: BigNumber,
-      user: Signer,
-      bundleId: BigNumber,
-    ) => {
-      await mint(token, user, amount);
-      await approve(token, user, assetWrapper.address, amount);
-      await assetWrapper.connect(user).depositERC20(token.address, amount, bundleId);
-    };
+    describe("ERC20", () => {
+      /**
+       * Set up a withdrawal test by depositing some ERC20s into a bundle
+       */
+      const deposit = async (
+        token: MockERC20,
+        assetWrapper: AssetWrapper,
+        amount: BigNumber,
+        user: Signer,
+        bundleId: BigNumber,
+      ) => {
+        await mint(token, user, amount);
+        await approve(token, user, assetWrapper.address, amount);
+        await assetWrapper.connect(user).depositERC20(token.address, amount, bundleId);
+      };
 
-    it("should withdraw single deposit from a bundle", async () => {
-      const { assetWrapper, mockERC20, user } = await setupTestContext();
-      const amount = hre.ethers.utils.parseUnits("50", 18);
-      const bundleId = await initializeBundle(assetWrapper, user);
-      await initializeAndDeposit(mockERC20, assetWrapper, amount, user, bundleId);
+      /**
+       * Set up a withdrawal test by initializing a bundle and depositing some ERC20s
+       */
+      const initializeAndDeposit = async (
+        token: MockERC20,
+        assetWrapper: AssetWrapper,
+        amount: BigNumber,
+        user: Signer,
+      ) => {
+        const bundleId = await initializeBundle(assetWrapper, user);
+        await deposit(token, assetWrapper, amount, user, bundleId);
+        return bundleId;
+      };
 
-      await expect(assetWrapper.connect(user).withdraw(bundleId))
-        .to.emit(mockERC20, "Transfer")
-        .withArgs(assetWrapper.address, await user.getAddress(), amount);
+      it("should withdraw single deposit from a bundle", async () => {
+        const { assetWrapper, mockERC20, user } = await setupTestContext();
+        const amount = hre.ethers.utils.parseUnits("50", 18);
+        const bundleId = await initializeAndDeposit(mockERC20, assetWrapper, amount, user);
+
+        await expect(assetWrapper.connect(user).withdraw(bundleId))
+          .to.emit(assetWrapper, "Withdraw")
+          .withArgs(await user.getAddress(), bundleId)
+          .to.emit(mockERC20, "Transfer")
+          .withArgs(assetWrapper.address, await user.getAddress(), amount);
+      });
+
+      it("should withdraw multiple deposits of the same token from a bundle", async () => {
+        const { assetWrapper, mockERC20, user } = await setupTestContext();
+        const amount = hre.ethers.utils.parseUnits("50", 18);
+        const bundleId = await initializeAndDeposit(mockERC20, assetWrapper, amount, user);
+        const secondAmount = hre.ethers.utils.parseUnits("14", 18);
+        await deposit(mockERC20, assetWrapper, secondAmount, user, bundleId);
+
+        await expect(assetWrapper.connect(user).withdraw(bundleId))
+          .to.emit(assetWrapper, "Withdraw")
+          .withArgs(await user.getAddress(), bundleId)
+          .to.emit(mockERC20, "Transfer")
+          .withArgs(assetWrapper.address, await user.getAddress(), amount)
+          .to.emit(mockERC20, "Transfer")
+          .withArgs(assetWrapper.address, await user.getAddress(), secondAmount);
+      });
+
+      it("should withdraw deposits of multiple tokens from a bundle", async () => {
+        const { assetWrapper, user } = await setupTestContext();
+        const amount = hre.ethers.utils.parseUnits("50", 18);
+        const bundleId = await initializeBundle(assetWrapper, user);
+
+        const tokens = [];
+        for (let i = 0; i < 10; i++) {
+          const mockERC20 = <MockERC20>await deploy("MockERC20", user, ["Mock ERC20", "MOCK" + i]);
+          await deposit(mockERC20, assetWrapper, amount, user, bundleId);
+          tokens.push(mockERC20);
+        }
+
+        let expectation = expect(assetWrapper.connect(user).withdraw(bundleId))
+          .to.emit(assetWrapper, "Withdraw")
+          .withArgs(await user.getAddress(), bundleId);
+
+        for (const token of tokens) {
+          expectation = expectation.to
+            .emit(token, "Transfer")
+            .withArgs(assetWrapper.address, await user.getAddress(), amount);
+        }
+        await expectation;
+      });
+
+      it("should throw when already withdrawn", async () => {
+        const { assetWrapper, mockERC20, user } = await setupTestContext();
+        const amount = hre.ethers.utils.parseUnits("50", 18);
+        const bundleId = await initializeAndDeposit(mockERC20, assetWrapper, amount, user);
+
+        await expect(assetWrapper.connect(user).withdraw(bundleId))
+          .to.emit(assetWrapper, "Withdraw")
+          .withArgs(await user.getAddress(), bundleId)
+          .to.emit(mockERC20, "Transfer")
+          .withArgs(assetWrapper.address, await user.getAddress(), amount);
+
+        await expect(assetWrapper.connect(user).withdraw(bundleId)).to.be.revertedWith(
+          "ERC721: operator query for nonexistent token",
+        );
+      });
+
+      it("should throw when withdraw called by non-owner", async () => {
+        const { assetWrapper, mockERC20, user, other } = await setupTestContext();
+        const amount = hre.ethers.utils.parseUnits("50", 18);
+        const bundleId = await initializeAndDeposit(mockERC20, assetWrapper, amount, user);
+
+        await expect(assetWrapper.connect(other).withdraw(bundleId)).to.be.revertedWith(
+          "AssetWrapper: Non-owner withdrawal",
+        );
+      });
+
+      it("should withdraw when non-owner calls with approval", async () => {
+        const { assetWrapper, mockERC20, user, other } = await setupTestContext();
+        const amount = hre.ethers.utils.parseUnits("50", 18);
+        const bundleId = await initializeAndDeposit(mockERC20, assetWrapper, amount, user);
+
+        await assetWrapper.connect(user).approve(await other.getAddress(), bundleId);
+        await expect(assetWrapper.connect(other).withdraw(bundleId))
+          .to.emit(assetWrapper, "Withdraw")
+          .withArgs(await other.getAddress(), bundleId)
+          .to.emit(mockERC20, "Transfer")
+          .withArgs(assetWrapper.address, await other.getAddress(), amount);
+      });
+
+      it("should throw when non-owner calls with approval to AssetWrapper", async () => {
+        const { assetWrapper, mockERC20, user, other } = await setupTestContext();
+        const amount = hre.ethers.utils.parseUnits("50", 18);
+        const bundleId = await initializeAndDeposit(mockERC20, assetWrapper, amount, user);
+
+        await assetWrapper.connect(user).approve(assetWrapper.address, bundleId);
+        await expect(assetWrapper.connect(other).withdraw(bundleId)).to.be.revertedWith(
+          "AssetWrapper: Non-owner withdrawal",
+        );
+      });
     });
 
-    it("should throw when withdraw called by non-owner", async () => {
-      const { assetWrapper, mockERC20, user, other } = await setupTestContext();
-      const amount = hre.ethers.utils.parseUnits("50", 18);
-      const bundleId = await initializeBundle(assetWrapper, user);
-      await initializeAndDeposit(mockERC20, assetWrapper, amount, user, bundleId);
+    describe("ERC721", () => {
+      /**
+       * Set up a withdrawal test by depositing some ERC721s into a bundle
+       */
+      const initializeAndDeposit = async (token: MockERC721, assetWrapper: AssetWrapper, user: Signer) => {
+        const bundleId = await initializeBundle(assetWrapper, user);
+        const tokenId = await mintERC721(token, user);
+        await approveERC721(token, user, assetWrapper.address, tokenId);
+        await assetWrapper.connect(user).depositERC721(token.address, tokenId, bundleId);
+        return { tokenId, bundleId };
+      };
 
-      await expect(assetWrapper.connect(other).withdraw(bundleId)).to.be.reverted;
+      it("should withdraw single deposit from a bundle", async () => {
+        const { assetWrapper, mockERC721, user } = await setupTestContext();
+        const { tokenId, bundleId } = await initializeAndDeposit(mockERC721, assetWrapper, user);
+
+        await expect(assetWrapper.connect(user).withdraw(bundleId))
+          .to.emit(assetWrapper, "Withdraw")
+          .withArgs(await user.getAddress(), bundleId)
+          .to.emit(mockERC721, "Transfer")
+          .withArgs(assetWrapper.address, await user.getAddress(), tokenId)
+          .to.emit(mockERC721, "Approval")
+          .withArgs(assetWrapper.address, ZERO_ADDRESS, tokenId);
+      });
+
+      it("should throw when already withdrawn", async () => {
+        const { assetWrapper, mockERC721, user } = await setupTestContext();
+        const { tokenId, bundleId } = await initializeAndDeposit(mockERC721, assetWrapper, user);
+
+        await expect(assetWrapper.connect(user).withdraw(bundleId))
+          .to.emit(assetWrapper, "Withdraw")
+          .withArgs(await user.getAddress(), bundleId)
+          .to.emit(mockERC721, "Transfer")
+          .withArgs(assetWrapper.address, await user.getAddress(), tokenId)
+          .to.emit(mockERC721, "Approval")
+          .withArgs(assetWrapper.address, ZERO_ADDRESS, tokenId);
+
+        await expect(assetWrapper.connect(user).withdraw(bundleId)).to.be.revertedWith(
+          "ERC721: operator query for nonexistent token",
+        );
+      });
+
+      it("should throw when withdraw called by non-owner", async () => {
+        const { assetWrapper, mockERC721, user, other } = await setupTestContext();
+        const { bundleId } = await initializeAndDeposit(mockERC721, assetWrapper, user);
+
+        await expect(assetWrapper.connect(other).withdraw(bundleId)).to.be.revertedWith(
+          "AssetWrapper: Non-owner withdrawal",
+        );
+      });
+
+      it("should withdraw when non-owner calls with approval", async () => {
+        const { assetWrapper, mockERC721, user, other } = await setupTestContext();
+        const { tokenId, bundleId } = await initializeAndDeposit(mockERC721, assetWrapper, user);
+
+        await assetWrapper.connect(user).approve(await other.getAddress(), bundleId);
+        await expect(assetWrapper.connect(other).withdraw(bundleId))
+          .to.emit(assetWrapper, "Withdraw")
+          .withArgs(await other.getAddress(), bundleId)
+          .to.emit(mockERC721, "Transfer")
+          .withArgs(assetWrapper.address, await other.getAddress(), tokenId)
+          .to.emit(mockERC721, "Approval")
+          .withArgs(assetWrapper.address, ZERO_ADDRESS, tokenId);
+      });
+
+      it("should throw when non-owner calls with approval to AssetWrapper", async () => {
+        const { assetWrapper, mockERC721, user, other } = await setupTestContext();
+        const { bundleId } = await initializeAndDeposit(mockERC721, assetWrapper, user);
+
+        await assetWrapper.connect(user).approve(assetWrapper.address, bundleId);
+        await expect(assetWrapper.connect(other).withdraw(bundleId)).to.be.revertedWith(
+          "AssetWrapper: Non-owner withdrawal",
+        );
+      });
     });
 
-    it("should withdraw when non-owner calls with approval", async () => {
-      const { assetWrapper, mockERC20, user, other } = await setupTestContext();
-      const amount = hre.ethers.utils.parseUnits("50", 18);
-      const bundleId = await initializeBundle(assetWrapper, user);
-      await initializeAndDeposit(mockERC20, assetWrapper, amount, user, bundleId);
+    describe("ERC1155", () => {
+      /**
+       * Set up a withdrawal test by depositing some ERC1155s into a bundle
+       */
+      const initializeAndDeposit = async (
+        token: MockERC1155,
+        assetWrapper: AssetWrapper,
+        user: Signer,
+        amount: BigNumber,
+      ) => {
+        const bundleId = await initializeBundle(assetWrapper, user);
+        const tokenId = await mintERC1155(token, user, amount);
+        await approveERC1155(token, user, assetWrapper.address);
+        await assetWrapper.connect(user).depositERC1155(token.address, tokenId, amount, bundleId);
+        return { tokenId, bundleId };
+      };
 
-      await assetWrapper.connect(user).approve(await other.getAddress(), bundleId);
-      await expect(assetWrapper.connect(other).withdraw(bundleId))
-        .to.emit(mockERC20, "Transfer")
-        .withArgs(assetWrapper.address, await other.getAddress(), amount);
+      it("should withdraw single deposit from a bundle", async () => {
+        const { assetWrapper, mockERC1155, user } = await setupTestContext();
+        const amount = BigNumber.from("1");
+        const { tokenId, bundleId } = await initializeAndDeposit(mockERC1155, assetWrapper, user, amount);
+
+        await expect(assetWrapper.connect(user).withdraw(bundleId))
+          .to.emit(assetWrapper, "Withdraw")
+          .withArgs(await user.getAddress(), bundleId)
+          .to.emit(mockERC1155, "TransferSingle")
+          .withArgs(assetWrapper.address, assetWrapper.address, await user.getAddress(), tokenId, amount);
+      });
+
+      it("should withdraw fungible deposit from a bundle", async () => {
+        const { assetWrapper, mockERC1155, user } = await setupTestContext();
+        const amount = hre.ethers.utils.parseEther("100");
+        const { tokenId, bundleId } = await initializeAndDeposit(mockERC1155, assetWrapper, user, amount);
+
+        await expect(assetWrapper.connect(user).withdraw(bundleId))
+          .to.emit(assetWrapper, "Withdraw")
+          .withArgs(await user.getAddress(), bundleId)
+          .to.emit(mockERC1155, "TransferSingle")
+          .withArgs(assetWrapper.address, assetWrapper.address, await user.getAddress(), tokenId, amount);
+      });
+
+      it("should throw when already withdrawn", async () => {
+        const { assetWrapper, mockERC1155, user } = await setupTestContext();
+        const amount = BigNumber.from("1");
+        const { tokenId, bundleId } = await initializeAndDeposit(mockERC1155, assetWrapper, user, amount);
+
+        await expect(assetWrapper.connect(user).withdraw(bundleId))
+          .to.emit(assetWrapper, "Withdraw")
+          .withArgs(await user.getAddress(), bundleId)
+          .to.emit(mockERC1155, "TransferSingle")
+          .withArgs(assetWrapper.address, assetWrapper.address, await user.getAddress(), tokenId, amount);
+
+        await expect(assetWrapper.connect(user).withdraw(bundleId)).to.be.revertedWith(
+          "ERC721: operator query for nonexistent token",
+        );
+      });
+
+      it("should throw when withdraw called by non-owner", async () => {
+        const { assetWrapper, mockERC1155, user, other } = await setupTestContext();
+        const amount = BigNumber.from("1");
+        const { bundleId } = await initializeAndDeposit(mockERC1155, assetWrapper, user, amount);
+
+        await expect(assetWrapper.connect(other).withdraw(bundleId)).to.be.revertedWith(
+          "AssetWrapper: Non-owner withdrawal",
+        );
+      });
+
+      it("should withdraw when non-owner calls with approval", async () => {
+        const { assetWrapper, mockERC1155, user, other } = await setupTestContext();
+        const amount = BigNumber.from("1");
+        const { tokenId, bundleId } = await initializeAndDeposit(mockERC1155, assetWrapper, user, amount);
+
+        await assetWrapper.connect(user).approve(await other.getAddress(), bundleId);
+        await expect(assetWrapper.connect(other).withdraw(bundleId))
+          .to.emit(assetWrapper, "Withdraw")
+          .withArgs(await other.getAddress(), bundleId)
+          .to.emit(mockERC1155, "TransferSingle")
+          .withArgs(assetWrapper.address, assetWrapper.address, await other.getAddress(), tokenId, amount);
+      });
+
+      it("should throw when non-owner calls with approval to AssetWrapper", async () => {
+        const { assetWrapper, mockERC1155, user, other } = await setupTestContext();
+        const amount = BigNumber.from("1");
+        const { bundleId } = await initializeAndDeposit(mockERC1155, assetWrapper, user, amount);
+
+        await assetWrapper.connect(user).approve(assetWrapper.address, bundleId);
+        await expect(assetWrapper.connect(other).withdraw(bundleId)).to.be.revertedWith(
+          "AssetWrapper: Non-owner withdrawal",
+        );
+      });
     });
 
-    it("should throw when non-owner calls with approval to AssetWrapper", async () => {
-      const { assetWrapper, mockERC20, user, other } = await setupTestContext();
-      const amount = hre.ethers.utils.parseUnits("50", 18);
-      const bundleId = await initializeBundle(assetWrapper, user);
-      await initializeAndDeposit(mockERC20, assetWrapper, amount, user, bundleId);
+    describe("ETH", () => {
+      const deposit = async (assetWrapper: AssetWrapper, user: Signer, amount: BigNumber, bundleId: BigNumber) => {
+        await assetWrapper.connect(user).depositETH(bundleId, { value: amount });
+      };
 
-      await assetWrapper.connect(user).approve(assetWrapper.address, bundleId);
-      await expect(assetWrapper.connect(other).withdraw(bundleId)).to.be.reverted;
+      /**
+       * Set up a withdrawal test by initializing and depositing some ETH into a bundle
+       */
+      const initializeAndDeposit = async (assetWrapper: AssetWrapper, user: Signer, amount: BigNumber) => {
+        const bundleId = await initializeBundle(assetWrapper, user);
+        await deposit(assetWrapper, user, amount, bundleId);
+        return bundleId;
+      };
+
+      it("should withdraw single deposit from a bundle", async () => {
+        const { assetWrapper, user } = await setupTestContext();
+        const amount = hre.ethers.utils.parseEther("123");
+        const bundleId = await initializeAndDeposit(assetWrapper, user, amount);
+        const startingBalance = BigNumber.from(
+          await hre.network.provider.send("eth_getBalance", [await user.getAddress(), "latest"]),
+        );
+
+        await expect(assetWrapper.connect(user).withdraw(bundleId))
+          .to.emit(assetWrapper, "Withdraw")
+          .withArgs(await user.getAddress(), bundleId);
+
+        const threshold = hre.ethers.utils.parseEther("0.001"); // for txn fee
+        const endingBalance = BigNumber.from(
+          await hre.network.provider.send("eth_getBalance", [await user.getAddress(), "latest"]),
+        );
+        expect(endingBalance.sub(startingBalance).gt(amount.sub(threshold))).to.be.true;
+      });
+
+      it("should throw when already withdrawn", async () => {
+        const { assetWrapper, user } = await setupTestContext();
+        const amount = hre.ethers.utils.parseEther("14");
+        const bundleId = await initializeAndDeposit(assetWrapper, user, amount);
+
+        await expect(assetWrapper.connect(user).withdraw(bundleId))
+          .to.emit(assetWrapper, "Withdraw")
+          .withArgs(await user.getAddress(), bundleId);
+
+        await expect(assetWrapper.connect(user).withdraw(bundleId)).to.be.revertedWith(
+          "ERC721: operator query for nonexistent token",
+        );
+      });
+
+      it("should throw when withdraw called by non-owner", async () => {
+        const { assetWrapper, user, other } = await setupTestContext();
+        const amount = hre.ethers.utils.parseEther("9");
+        const bundleId = await initializeAndDeposit(assetWrapper, user, amount);
+
+        await expect(assetWrapper.connect(other).withdraw(bundleId)).to.be.revertedWith(
+          "AssetWrapper: Non-owner withdrawal",
+        );
+      });
+
+      it("should withdraw when non-owner calls with approval", async () => {
+        const { assetWrapper, user, other } = await setupTestContext();
+        const amount = hre.ethers.utils.parseEther("94");
+        const bundleId = await initializeAndDeposit(assetWrapper, user, amount);
+
+        await assetWrapper.connect(user).approve(await other.getAddress(), bundleId);
+        await expect(assetWrapper.connect(other).withdraw(bundleId))
+          .to.emit(assetWrapper, "Withdraw")
+          .withArgs(await other.getAddress(), bundleId);
+      });
+
+      it("should throw when non-owner calls with approval to AssetWrapper", async () => {
+        const { assetWrapper, user, other } = await setupTestContext();
+        const amount = hre.ethers.utils.parseEther("64");
+        const bundleId = await initializeAndDeposit(assetWrapper, user, amount);
+
+        await assetWrapper.connect(user).approve(assetWrapper.address, bundleId);
+        await expect(assetWrapper.connect(other).withdraw(bundleId)).to.be.revertedWith(
+          "AssetWrapper: Non-owner withdrawal",
+        );
+      });
     });
   });
 
@@ -250,7 +873,9 @@ describe("AssetWrapper", () => {
 
         context("when querying the zero address", function () {
           it("throws", async function () {
-            await expect(token.balanceOf(ZERO_ADDRESS)).to.be.reverted;
+            await expect(token.balanceOf(ZERO_ADDRESS)).to.be.revertedWith(
+              "ERC721: balance query for the zero address",
+            );
           });
         });
       });
@@ -265,7 +890,9 @@ describe("AssetWrapper", () => {
 
         context("when the given token ID was not tracked by this token", function () {
           it("reverts", async function () {
-            await expect(token.ownerOf(BigNumber.from("123412341234"))).to.be.reverted;
+            await expect(token.ownerOf(BigNumber.from("123412341234"))).to.be.revertedWith(
+              "ERC721: owner query for nonexistent token",
+            );
           });
         });
       });
@@ -297,13 +924,17 @@ describe("AssetWrapper", () => {
             if (postSenderBalance.gt(0)) {
               expect(await token.tokenOfOwnerByIndex(await from.getAddress(), 0)).to.not.equal(tokenId);
             } else {
-              await expect(token.tokenOfOwnerByIndex(await from.getAddress(), 0)).to.be.reverted;
+              await expect(token.tokenOfOwnerByIndex(await from.getAddress(), 0)).to.be.revertedWith(
+                "ERC721Enumerable: owner index out of bounds",
+              );
             }
 
             if (postRecipientBalance.gt(0)) {
               expect(await token.tokenOfOwnerByIndex(await to.getAddress(), 0)).to.equal(tokenId);
             } else {
-              await expect(token.tokenOfOwnerByIndex(await to.getAddress(), 0)).to.be.reverted;
+              await expect(token.tokenOfOwnerByIndex(await to.getAddress(), 0)).to.be.revertedWith(
+                "ERC721Enumerable: owner index out of bounds",
+              );
             }
           };
 
@@ -353,27 +984,30 @@ describe("AssetWrapper", () => {
 
           it("fails when the owner address is incorrect", async () => {
             const tokenId = await initializeBundle(token, user);
-            await expect(token.connect(user).transferFrom(await other.getAddress(), await other.getAddress(), tokenId))
-              .to.be.reverted;
+            await expect(
+              token.connect(user).transferFrom(await other.getAddress(), await other.getAddress(), tokenId),
+            ).to.be.revertedWith("ERC721: transfer of token that is not own");
           });
 
           it("fails when the sender is not authorized", async () => {
             const tokenId = await initializeBundle(token, user);
-            await expect(token.connect(other).transferFrom(await user.getAddress(), await other.getAddress(), tokenId))
-              .to.be.reverted;
+            await expect(
+              token.connect(other).transferFrom(await user.getAddress(), await other.getAddress(), tokenId),
+            ).to.be.revertedWith("ERC721: transfer caller is not owner nor approved");
           });
 
           it("fails when the token id does not exist", async () => {
             const nonexistentTokenId = BigNumber.from("123412341243");
             await expect(
               token.connect(user).transferFrom(await user.getAddress(), await other.getAddress(), nonexistentTokenId),
-            ).to.be.reverted;
+            ).to.be.revertedWith("ERC721: operator query for nonexistent token");
           });
 
           it("fails when the recipient is the zero address", async () => {
             const tokenId = await initializeBundle(token, user);
-            await expect(token.connect(user).transferFrom(await user.getAddress(), ZERO_ADDRESS, tokenId)).to.be
-              .reverted;
+            await expect(
+              token.connect(user).transferFrom(await user.getAddress(), ZERO_ADDRESS, tokenId),
+            ).to.be.revertedWith("zero");
           });
         });
       });

--- a/test/utils/erc1155.ts
+++ b/test/utils/erc1155.ts
@@ -1,0 +1,32 @@
+import { expect } from "chai";
+import { Signer, BigNumber } from "ethers";
+import { MockERC1155 } from "../../typechain";
+
+export const ZERO_ADDRESS = "0x0000000000000000000000000000000000000000";
+
+/**
+ * Mint tokens for `to`
+ */
+export const mint = async (token: MockERC1155, to: Signer, amount: BigNumber): Promise<string> => {
+  const address = await to.getAddress();
+
+  const tx = await token.mint(address, amount);
+  const receipt = await tx.wait();
+
+  if (receipt && receipt.events && receipt.events.length === 1 && receipt.events[0].args) {
+    return receipt.events[0].args.id;
+  } else {
+    throw new Error("Unable to initialize bundle");
+  }
+};
+
+/**
+ * approve `amount` tokens for `to` from `from`
+ */
+export const approve = async (token: MockERC1155, sender: Signer, toAddress: string): Promise<void> => {
+  const senderAddress = await sender.getAddress();
+
+  await expect(token.connect(sender).setApprovalForAll(toAddress, true))
+    .to.emit(token, "ApprovalForAll")
+    .withArgs(senderAddress, toAddress, true);
+};

--- a/test/utils/erc721.ts
+++ b/test/utils/erc721.ts
@@ -1,0 +1,35 @@
+import { expect } from "chai";
+import { Signer } from "ethers";
+import { MockERC721 } from "../../typechain/MockERC721";
+
+export const ZERO_ADDRESS = "0x0000000000000000000000000000000000000000";
+
+/**
+ * Mint tokens for `to`
+ */
+export const mint = async (token: MockERC721, to: Signer): Promise<string> => {
+  const address = await to.getAddress();
+
+  const tx = await token.mint(address);
+  const receipt = await tx.wait();
+
+  if (receipt && receipt.events && receipt.events.length === 1 && receipt.events[0].args) {
+    return receipt.events[0].args.tokenId;
+  } else {
+    throw new Error("Unable to initialize bundle");
+  }
+};
+
+/**
+ * approve `amount` tokens for `to` from `from`
+ */
+export const approve = async (token: MockERC721, sender: Signer, toAddress: string, tokenId: string): Promise<void> => {
+  const senderAddress = await sender.getAddress();
+  expect(await token.getApproved(tokenId)).to.not.equal(toAddress);
+
+  await expect(token.connect(sender).approve(toAddress, tokenId))
+    .to.emit(token, "Approval")
+    .withArgs(senderAddress, toAddress, tokenId);
+
+  expect(await token.getApproved(tokenId)).to.equal(toAddress);
+};


### PR DESCRIPTION
This commit adds support for multiple asset types to the cNFT asset
wrapper. The new types added are ERC721 tokens, ERC1155 tokens, and ETH.

Ticket: PAWN-30
