### PR TITLE
feat(core): add loan core

### DIFF
--- a/contracts/LoanCore.sol
+++ b/contracts/LoanCore.sol
@@ -1,0 +1,188 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+import "@openzeppelin/contracts/utils/math/SafeMath.sol";
+import "@openzeppelin/contracts/token/ERC721/IERC721.sol";
+import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import "@openzeppelin/contracts/utils/Counters.sol";
+import "./interfaces/INote.sol";
+import "./interfaces/IAssetWrapper.sol";
+import "./interfaces/ILoanCore.sol";
+
+/**
+ * TODO:
+ * Add onlyOriginationController
+ * Add onlyRepaymentController
+ * Fetch fees from FeeController
+ * Add admin permissions to update origination controller, repayment controller
+ * Add fee collection mechanism
+ */
+
+/**
+ * @dev Interface for the LoanCore contract
+ */
+contract LoanCore is ILoanCore {
+    using Counters for Counters.Counter;
+    Counters.Counter private loanIdTracker;
+    using SafeMath for uint256;
+
+    mapping(uint256 => LoanData) private loans;
+    mapping(uint256 => bool) private collateralInUse;
+    INote private borrowerNote;
+    INote private lenderNote;
+    IERC721 private collateralToken;
+
+    // TODO: fetch this from fee controller when available
+    uint256 private constant PROTOCOL_FEE_BPS = 300;
+    uint256 private constant BPS_DENOMINATOR = 10000;
+
+    mapping(address => uint256) private tokenBalances;
+
+    constructor(
+        INote _borrowerNote,
+        INote _lenderNote,
+        IERC721 _collateralToken
+    ) {
+        borrowerNote = _borrowerNote;
+        lenderNote = _lenderNote;
+        collateralToken = _collateralToken;
+    }
+
+    /**
+     * @inheritdoc ILoanCore
+     */
+    function getLoan(uint256 loanId) external view override returns (LoanData memory loanData) {
+        return loans[loanId];
+    }
+
+    /**
+     * @inheritdoc ILoanCore
+     */
+    function createLoan(LoanTerms calldata terms) external override returns (uint256 loanId) {
+        require(terms.dueDate > block.timestamp, "LoanCore::create: Loan is already expired");
+        require(!collateralInUse[terms.collateralTokenId], "LoanCore::create: Collateral token already in use");
+
+        // The following line could be removed to save gas
+        // as it will be implicitly ensured in startLoan when we take ownership of the collateral
+        require(
+            collateralToken.ownerOf(terms.collateralTokenId) != address(0),
+            "LoanCore::create: nonexistent collateral"
+        );
+
+        loanId = loanIdTracker.current();
+        loanIdTracker.increment();
+
+        loans[loanId] = LoanData(0, 0, terms, LoanState.Created);
+        collateralInUse[terms.collateralTokenId] = true;
+        emit LoanCreated(terms, loanId);
+    }
+
+    /**
+     * @inheritdoc ILoanCore
+     */
+    function startLoan(
+        address lender,
+        address borrower,
+        uint256 loanId
+    ) external override {
+        LoanData memory data = loans[loanId];
+        // Ensure valid initial loan state
+        require(data.state == LoanState.Created, "LoanCore::start: Invalid loan state");
+        // Ensure collateral and principal were deposited
+        require(
+            collateralToken.ownerOf(data.terms.collateralTokenId) == address(this),
+            "LoanCore::start: collateral not sent"
+        );
+        uint256 received = tokensReceived(IERC20(data.terms.payableCurrency));
+        require(received >= data.terms.principal, "LoanCore::start: Insufficient lender deposit");
+
+        // Distribute notes and principal
+        loans[loanId].state = LoanState.Active;
+        uint256 borrowerNoteId = borrowerNote.mint(borrower);
+        uint256 lenderNoteId = lenderNote.mint(lender);
+
+        // TODO: test if this is more/less costly than just setting the fields
+        loans[loanId] = LoanData(borrowerNoteId, lenderNoteId, data.terms, LoanState.Active);
+        IERC20(data.terms.payableCurrency).transfer(borrower, getPrincipalLessFees(data.terms.principal));
+
+        updateTokenBalance(IERC20(data.terms.payableCurrency));
+        emit LoanStarted(loanId, lender, borrower);
+    }
+
+    /**
+     * @inheritdoc ILoanCore
+     */
+    function repay(uint256 loanId) external override {
+        LoanData memory data = loans[loanId];
+        // Ensure valid initial loan state
+        require(data.state == LoanState.Active, "LoanCore::repay: Invalid loan state");
+        // NOTE: maybe we should remove this line, i.e. allow repayment of expired loan
+        require(data.terms.dueDate > block.timestamp, "LoanCore::repay: Loan expired");
+
+        // ensure repayment was valid
+        uint256 returnAmount = data.terms.principal.add(data.terms.interest);
+        uint256 received = tokensReceived(IERC20(data.terms.payableCurrency));
+        require(received >= returnAmount, "LoanCore::repay: Insufficient repayment");
+
+        address lender = lenderNote.ownerOf(data.lenderNoteId);
+        address borrower = borrowerNote.ownerOf(data.borrowerNoteId);
+
+        // state changes and cleanup
+        // NOTE: these must be performed before assets are released to prevent reentrance
+        loans[loanId].state = LoanState.Repaid;
+        lenderNote.burn(data.lenderNoteId);
+        borrowerNote.burn(data.borrowerNoteId);
+
+        // asset and collateral redistribution
+        IERC20(data.terms.payableCurrency).transfer(lender, returnAmount);
+        collateralToken.transferFrom(address(this), borrower, data.terms.collateralTokenId);
+
+        updateTokenBalance(IERC20(data.terms.payableCurrency));
+
+        emit LoanRepaid(loanId);
+    }
+
+    /**
+     * @inheritdoc ILoanCore
+     */
+    function claim(uint256 loanId) external override {
+        LoanData memory data = loans[loanId];
+        // Ensure valid initial loan state
+        require(data.state == LoanState.Active, "LoanCore::claim: Invalid loan state");
+        require(data.terms.dueDate < block.timestamp, "LoanCore::claim: Loan not expired");
+
+        address lender = lenderNote.ownerOf(data.lenderNoteId);
+
+        // NOTE: these must be performed before assets are released to prevent reentrance
+        loans[loanId].state = LoanState.Defaulted;
+        lenderNote.burn(data.lenderNoteId);
+        borrowerNote.burn(data.borrowerNoteId);
+
+        // collateral redistribution
+        collateralToken.transferFrom(address(this), lender, data.terms.collateralTokenId);
+
+        emit LoanClaimed(loanId);
+    }
+
+    /**
+     * @dev Check the amount of tokens received for a given ERC20 token since last checked
+     */
+    function tokensReceived(IERC20 token) internal view returns (uint256 amount) {
+        amount = token.balanceOf(address(this)).sub(tokenBalances[address(token)]);
+    }
+
+    /**
+     * @dev Update the internal state of our token balance for the given token
+     */
+    function updateTokenBalance(IERC20 token) internal {
+        tokenBalances[address(token)] = token.balanceOf(address(this));
+    }
+
+    /**
+     * Take a principal value and return the amount less protocol fees
+     */
+    function getPrincipalLessFees(uint256 principal) internal pure returns (uint256) {
+        // TODO: Fetch protocol fee from the fee controller
+        return principal.sub(principal.mul(PROTOCOL_FEE_BPS).div(BPS_DENOMINATOR));
+    }
+}

--- a/contracts/interfaces/ILoanCore.sol
+++ b/contracts/interfaces/ILoanCore.sol
@@ -9,6 +9,9 @@ pragma solidity ^0.8.0;
  *                    -> Defaulted
  */
 enum LoanState {
+    // Dummy enum value so all valid values are non-zero
+    // this avoids an issue where an uninitialized loan has a valid state of Created
+    DUMMY_DO_NOT_USE,
     // The loan data is stored, but not initiated yet.
     Created,
     // The loan has been initialized, funds have been delivered to the borrower and the collateral is held.

--- a/contracts/interfaces/INote.sol
+++ b/contracts/interfaces/INote.sol
@@ -1,0 +1,10 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+import "@openzeppelin/contracts/token/ERC721/IERC721.sol";
+
+interface INote is IERC721 {
+    function mint(address to) external returns (uint256 tokenId);
+
+    function burn(uint256 tokenId) external;
+}

--- a/contracts/test/MockERC721.sol
+++ b/contracts/test/MockERC721.sol
@@ -15,12 +15,20 @@ contract MockERC721 is Context, ERC721Enumerable {
     constructor(string memory name, string memory symbol) ERC721(name, symbol) {}
 
     /**
-     * @dev Creates `amount` new tokens for `to`. Public for any test to call.
+     * @dev Creates a new token for `to`. Public for any test to call.
      *
      * See {ERC721-_mint}.
      */
-    function mint(address to) public virtual {
-        _mint(to, _tokenIdTracker.current());
+    function mint(address to) external returns (uint256 tokenId) {
+        tokenId = _tokenIdTracker.current();
+        _mint(to, tokenId);
         _tokenIdTracker.increment();
+    }
+
+    /**
+     * @dev Burn the given token, can be called by anyone
+     */
+    function burn(uint256 tokenId) external {
+        _burn(tokenId);
     }
 }

--- a/test/LoanCore.ts
+++ b/test/LoanCore.ts
@@ -1,0 +1,673 @@
+import { expect } from "chai";
+import hre from "hardhat";
+import { BigNumber, BigNumberish, Signer } from "ethers";
+
+import { LoanCore, MockERC20, MockERC721 } from "../typechain";
+import { ZERO_ADDRESS } from "./utils/erc20";
+import { mint as mintERC721 } from "./utils/erc721";
+import { BlockchainTime } from "./utils/time";
+import { deploy } from "./utils/contracts";
+
+enum LoanState {
+  DUMMY = 0,
+  Created = 1,
+  Active = 2,
+  Repaid = 3,
+  Defaulted = 4,
+}
+
+const ZERO = hre.ethers.utils.parseUnits("0", 18);
+
+interface LoanTerms {
+  dueDate: BigNumberish;
+  principal: BigNumber;
+  interest: BigNumber;
+  collateralTokenId: BigNumber;
+  payableCurrency: string;
+}
+
+interface TestContext {
+  loanCore: LoanCore;
+  mockERC20: MockERC20;
+  mockBorrowerNote: MockERC721;
+  mockLenderNote: MockERC721;
+  mockAssetWrapper: MockERC721;
+  user: Signer;
+  other: Signer;
+  signers: Signer[];
+}
+
+describe("LoanCore", () => {
+  const blockchainTime = new BlockchainTime();
+
+  /**
+   * Sets up a test context, deploying new contracts and returning them for use in a test
+   */
+  const setupTestContext = async (): Promise<TestContext> => {
+    const signers: Signer[] = await hre.ethers.getSigners();
+
+    const mockBorrowerNote = <MockERC721>await deploy("MockERC721", signers[0], ["Mock BorrowerNote", "MB"]);
+    const mockLenderNote = <MockERC721>await deploy("MockERC721", signers[0], ["Mock LenderNote", "ML"]);
+    const mockAssetWrapper = <MockERC721>await deploy("MockERC721", signers[0], ["Mock AssetWrapper", "MA"]);
+    const loanCore = <LoanCore>(
+      await deploy("LoanCore", signers[0], [mockBorrowerNote.address, mockLenderNote.address, mockAssetWrapper.address])
+    );
+    const mockERC20 = <MockERC20>await deploy("MockERC20", signers[0], ["Mock ERC20", "MOCK"]);
+
+    return {
+      loanCore,
+      mockBorrowerNote,
+      mockLenderNote,
+      mockAssetWrapper,
+      mockERC20,
+      user: signers[0],
+      other: signers[1],
+      signers: signers.slice(2),
+    };
+  };
+
+  /**
+   * Create a LoanTerms object using the given parameters, or defaults
+   */
+  const createLoanTerms = (
+    payableCurrency: string,
+    {
+      dueDate = new Date(new Date().getTime() + 3600000).getTime(),
+      principal = hre.ethers.utils.parseEther("100"),
+      interest = hre.ethers.utils.parseEther("1"),
+      collateralTokenId = BigNumber.from(1),
+    }: Partial<LoanTerms> = {},
+  ): LoanTerms => {
+    return {
+      dueDate,
+      principal,
+      interest,
+      collateralTokenId,
+      payableCurrency,
+    };
+  };
+
+  /**
+   * Initialize a new loan, returning the loanId
+   */
+  const createLoan = async (loanCore: LoanCore, user: Signer, terms: LoanTerms): Promise<BigNumber> => {
+    const tx = await loanCore.connect(user).createLoan(terms);
+    const receipt = await tx.wait();
+
+    if (receipt && receipt.events && receipt.events.length === 1 && receipt.events[0].args) {
+      return receipt.events[0].args.loanId;
+    } else {
+      throw new Error("Unable to initialize loan");
+    }
+  };
+
+  /**
+   * Assert equality between two LoanTerms objects
+   */
+  const assertTermsEquality = (actual: LoanTerms, expected: LoanTerms) => {
+    expect(actual.dueDate).to.equal(expected.dueDate);
+    expect(actual.principal).to.equal(expected.principal);
+    expect(actual.interest).to.equal(expected.interest);
+    expect(actual.collateralTokenId).to.equal(expected.collateralTokenId);
+    expect(actual.payableCurrency).to.equal(expected.payableCurrency);
+  };
+
+  describe("Create Loan", function () {
+    it("should successfully create a loan", async () => {
+      const { loanCore, mockERC20, mockAssetWrapper, user } = await setupTestContext();
+      const collateralTokenId = await mintERC721(mockAssetWrapper, user);
+      const terms = createLoanTerms(mockERC20.address, { collateralTokenId });
+
+      const loanId = await createLoan(loanCore, user, terms);
+      expect(loanId.gte(ZERO)).to.be.true;
+
+      const storedLoanData = await loanCore.getLoan(loanId);
+      expect(storedLoanData.borrowerNoteId).to.equal(BigNumber.from(0));
+      expect(storedLoanData.lenderNoteId).to.equal(BigNumber.from(0));
+      expect(storedLoanData.state).to.equal(LoanState.Created);
+      assertTermsEquality(storedLoanData.terms, terms);
+    });
+
+    it("should emit the LoanCreated event", async () => {
+      const { loanCore, mockERC20, mockAssetWrapper, user } = await setupTestContext();
+      const collateralTokenId = await mintERC721(mockAssetWrapper, user);
+      const terms = createLoanTerms(mockERC20.address, { collateralTokenId });
+
+      await expect(loanCore.connect(user).createLoan(terms)).to.emit(loanCore, "LoanCreated");
+    });
+
+    it("should successfully create a bunch of loans with different loanIds", async () => {
+      const { loanCore, mockERC20, mockAssetWrapper, user } = await setupTestContext();
+
+      const loanIds = new Set();
+      for (let i = 0; i < 10; i++) {
+        const collateralTokenId = await mintERC721(mockAssetWrapper, user);
+        const terms = createLoanTerms(mockERC20.address, { collateralTokenId });
+
+        const loanId = await createLoan(loanCore, user, terms);
+        expect(loanIds.has(loanId)).to.be.false;
+        loanIds.add(loanId);
+      }
+    });
+
+    it("should fail to create a loan with nonexistent collateral", async () => {
+      const { loanCore, mockERC20, user } = await setupTestContext();
+      const terms = createLoanTerms(mockERC20.address);
+
+      await expect(createLoan(loanCore, user, terms)).to.be.revertedWith("ERC721: owner query for nonexistent token");
+    });
+
+    it("should fail to create a loan with passed due date", async () => {
+      const { loanCore, mockERC20, mockAssetWrapper, user } = await setupTestContext();
+      const collateralTokenId = await mintERC721(mockAssetWrapper, user);
+      const terms = createLoanTerms(mockERC20.address, {
+        collateralTokenId,
+        dueDate: await blockchainTime.secondsFromNow(-1000),
+      });
+
+      await expect(createLoan(loanCore, user, terms)).to.be.revertedWith("LoanCore::create: Loan is already expired");
+    });
+
+    it("should fail to create a loan with reused collateral", async () => {
+      const { loanCore, mockERC20, mockAssetWrapper, user } = await setupTestContext();
+      const collateralTokenId = await mintERC721(mockAssetWrapper, user);
+      const terms = createLoanTerms(mockERC20.address, { collateralTokenId });
+
+      await createLoan(loanCore, user, terms);
+
+      await expect(createLoan(loanCore, user, terms)).to.be.revertedWith(
+        "LoanCore::create: Collateral token already in use",
+      );
+    });
+
+    it("gas", async () => {
+      const { loanCore, mockERC20, mockAssetWrapper, user } = await setupTestContext();
+      const collateralTokenId = await mintERC721(mockAssetWrapper, user);
+      const terms = createLoanTerms(mockERC20.address, { collateralTokenId });
+
+      const tx = await loanCore.connect(user).createLoan(terms);
+      const receipt = await tx.wait();
+      const gasUsed = receipt.gasUsed;
+      expect(gasUsed.toString()).to.equal("176338");
+    });
+  });
+
+  describe("Start Loan", function () {
+    interface StartLoanState extends TestContext {
+      loanId: BigNumber;
+      terms: LoanTerms;
+      borrower: Signer;
+      lender: Signer;
+    }
+
+    const setupLoan = async (context?: TestContext, inputTerms?: Partial<LoanTerms>): Promise<StartLoanState> => {
+      context = context || (await setupTestContext());
+
+      const { mockAssetWrapper, mockERC20, loanCore, user: borrower, other: lender } = context;
+      const collateralTokenId = await mintERC721(mockAssetWrapper, borrower);
+      const terms = createLoanTerms(mockERC20.address, { collateralTokenId, ...inputTerms });
+      const loanId = await createLoan(loanCore, borrower, terms);
+      return { ...context, loanId, terms, borrower, lender };
+    };
+
+    it("should successfully start a loan", async () => {
+      const {
+        mockLenderNote,
+        mockBorrowerNote,
+        mockAssetWrapper,
+        loanCore,
+        mockERC20,
+        loanId,
+        terms: { collateralTokenId, principal },
+        borrower,
+        lender,
+      } = await setupLoan();
+      const borrowerBalanceBefore = await mockERC20.balanceOf(await borrower.getAddress());
+      const loanCoreBalanceBefore = await mockERC20.balanceOf(loanCore.address);
+
+      await mockAssetWrapper
+        .connect(borrower)
+        .transferFrom(await borrower.getAddress(), loanCore.address, collateralTokenId);
+      await mockERC20.connect(lender).mint(loanCore.address, principal);
+
+      await expect(loanCore.connect(borrower).startLoan(await lender.getAddress(), await borrower.getAddress(), loanId))
+        .to.emit(loanCore, "LoanStarted")
+        .withArgs(loanId, await lender.getAddress(), await borrower.getAddress());
+
+      const fee = principal.mul(3).div(100);
+      const borrowerBalanceAfter = await mockERC20.balanceOf(await borrower.getAddress());
+      expect(borrowerBalanceAfter.sub(borrowerBalanceBefore)).to.equal(principal.sub(fee));
+      const loanCoreBalanceAfter = await mockERC20.balanceOf(loanCore.address);
+      expect(loanCoreBalanceAfter.sub(loanCoreBalanceBefore)).to.equal(fee);
+
+      const storedLoanData = await loanCore.getLoan(loanId);
+      expect(storedLoanData.state).to.equal(LoanState.Active);
+      expect(await mockLenderNote.ownerOf(storedLoanData.lenderNoteId)).to.equal(await lender.getAddress());
+      expect(await mockBorrowerNote.ownerOf(storedLoanData.borrowerNoteId)).to.equal(await borrower.getAddress());
+    });
+
+    it("should successfully start two loans back to back", async () => {
+      const context = await setupTestContext();
+      const { mockAssetWrapper, loanCore, mockERC20 } = context;
+      let {
+        loanId,
+        terms: { collateralTokenId, principal },
+        borrower,
+        lender,
+      } = await setupLoan(context);
+      await mockAssetWrapper
+        .connect(borrower)
+        .transferFrom(await borrower.getAddress(), loanCore.address, collateralTokenId);
+      await mockERC20.connect(lender).mint(loanCore.address, principal);
+
+      await expect(loanCore.connect(borrower).startLoan(await lender.getAddress(), await borrower.getAddress(), loanId))
+        .to.emit(loanCore, "LoanStarted")
+        .withArgs(loanId, await lender.getAddress(), await borrower.getAddress());
+
+      ({
+        loanId,
+        terms: { collateralTokenId, principal },
+        borrower,
+        lender,
+      } = await setupLoan(context));
+      await mockAssetWrapper
+        .connect(borrower)
+        .transferFrom(await borrower.getAddress(), loanCore.address, collateralTokenId);
+      await mockERC20.connect(lender).mint(loanCore.address, principal);
+
+      await expect(loanCore.connect(borrower).startLoan(await lender.getAddress(), await borrower.getAddress(), loanId))
+        .to.emit(loanCore, "LoanStarted")
+        .withArgs(loanId, await lender.getAddress(), await borrower.getAddress());
+    });
+
+    it("should fail to start two loans where principal for both is paid at once", async () => {
+      const context = await setupTestContext();
+      const { mockAssetWrapper, loanCore, mockERC20 } = context;
+      let {
+        loanId,
+        terms: { collateralTokenId, principal },
+        borrower,
+        lender,
+      } = await setupLoan(context);
+      await mockAssetWrapper
+        .connect(borrower)
+        .transferFrom(await borrower.getAddress(), loanCore.address, collateralTokenId);
+      await mockERC20.connect(lender).mint(loanCore.address, principal.mul(2));
+
+      await expect(loanCore.connect(borrower).startLoan(await lender.getAddress(), await borrower.getAddress(), loanId))
+        .to.emit(loanCore, "LoanStarted")
+        .withArgs(loanId, await lender.getAddress(), await borrower.getAddress());
+
+      ({
+        loanId,
+        terms: { collateralTokenId, principal },
+        borrower,
+        lender,
+      } = await setupLoan(context));
+      await mockAssetWrapper
+        .connect(borrower)
+        .transferFrom(await borrower.getAddress(), loanCore.address, collateralTokenId);
+
+      // fails because the full input from the first loan was factored into the stored contract balance
+      await expect(
+        loanCore.connect(borrower).startLoan(await lender.getAddress(), await borrower.getAddress(), loanId),
+      ).to.be.revertedWith("LoanCore::start: Insufficient lender deposit");
+    });
+
+    it("should fail to start a loan that is not created", async () => {
+      const { loanCore, user: borrower, other: lender } = await setupLoan();
+      const loanId = BigNumber.from("123412341324");
+      await expect(
+        loanCore.connect(borrower).startLoan(await lender.getAddress(), await borrower.getAddress(), loanId),
+      ).to.be.revertedWith("LoanCore::start: Invalid loan state");
+    });
+
+    it("should fail to start a loan that is already started", async () => {
+      const {
+        mockAssetWrapper,
+        loanCore,
+        mockERC20,
+        loanId,
+        terms: { collateralTokenId, principal },
+        borrower,
+        lender,
+      } = await setupLoan();
+      await mockAssetWrapper
+        .connect(borrower)
+        .transferFrom(await borrower.getAddress(), loanCore.address, collateralTokenId);
+      await mockERC20.connect(lender).mint(loanCore.address, principal);
+
+      await loanCore.connect(borrower).startLoan(await lender.getAddress(), await borrower.getAddress(), loanId);
+      await expect(
+        loanCore.connect(borrower).startLoan(await lender.getAddress(), await borrower.getAddress(), loanId),
+      ).to.be.revertedWith("LoanCore::start: Invalid loan state");
+    });
+
+    it("should fail to start a loan that is repaid", async () => {
+      const {
+        mockAssetWrapper,
+        loanCore,
+        mockERC20,
+        loanId,
+        terms: { collateralTokenId, interest, principal },
+        borrower,
+        lender,
+      } = await setupLoan();
+      await mockAssetWrapper
+        .connect(borrower)
+        .transferFrom(await borrower.getAddress(), loanCore.address, collateralTokenId);
+      await mockERC20.connect(lender).mint(loanCore.address, principal);
+
+      await loanCore.connect(borrower).startLoan(await lender.getAddress(), await borrower.getAddress(), loanId);
+      await mockERC20.connect(borrower).mint(loanCore.address, principal.add(interest));
+
+      await loanCore.connect(borrower).repay(loanId);
+      await expect(
+        loanCore.connect(borrower).startLoan(await lender.getAddress(), await borrower.getAddress(), loanId),
+      ).to.be.revertedWith("LoanCore::start: Invalid loan state");
+    });
+
+    it("should fail to start a loan that is already claimed", async () => {
+      const {
+        mockAssetWrapper,
+        loanCore,
+        mockERC20,
+        loanId,
+        terms: { collateralTokenId, interest, principal },
+        borrower,
+        lender,
+      } = await setupLoan(undefined, { dueDate: await blockchainTime.secondsFromNow(1000) });
+      await mockAssetWrapper
+        .connect(borrower)
+        .transferFrom(await borrower.getAddress(), loanCore.address, collateralTokenId);
+      await mockERC20.connect(lender).mint(loanCore.address, principal);
+
+      await loanCore.connect(borrower).startLoan(await lender.getAddress(), await borrower.getAddress(), loanId);
+      await mockERC20.connect(borrower).mint(loanCore.address, principal.add(interest));
+
+      await blockchainTime.increaseTime(1001);
+
+      await loanCore.connect(borrower).claim(loanId);
+      await expect(
+        loanCore.connect(borrower).startLoan(await lender.getAddress(), await borrower.getAddress(), loanId),
+      ).to.be.revertedWith("LoanCore::start: Invalid loan state");
+    });
+
+    it("should fail to start a loan if collateral has not been sent", async () => {
+      const { loanCore, loanId, borrower, lender } = await setupLoan();
+      await expect(
+        loanCore.connect(borrower).startLoan(await lender.getAddress(), await borrower.getAddress(), loanId),
+      ).to.be.revertedWith("LoanCore::start: collateral not sent");
+    });
+
+    it("should fail to start a loan if lender did not deposit", async () => {
+      const {
+        mockAssetWrapper,
+        loanCore,
+        loanId,
+        terms: { collateralTokenId },
+        borrower,
+        lender,
+      } = await setupLoan();
+      await mockAssetWrapper
+        .connect(borrower)
+        .transferFrom(await borrower.getAddress(), loanCore.address, collateralTokenId);
+
+      await expect(
+        loanCore.connect(borrower).startLoan(await lender.getAddress(), await borrower.getAddress(), loanId),
+      ).to.be.revertedWith("LoanCore::start: Insufficient lender deposit");
+    });
+
+    it("should fail to start a loan if lender did not deposit enough", async () => {
+      const {
+        mockAssetWrapper,
+        loanCore,
+        mockERC20,
+        loanId,
+        terms: { collateralTokenId, principal },
+        borrower,
+        lender,
+      } = await setupLoan();
+      await mockAssetWrapper
+        .connect(borrower)
+        .transferFrom(await borrower.getAddress(), loanCore.address, collateralTokenId);
+      await mockERC20.connect(lender).mint(loanCore.address, principal.sub(1));
+
+      await expect(
+        loanCore.connect(borrower).startLoan(await lender.getAddress(), await borrower.getAddress(), loanId),
+      ).to.be.revertedWith("LoanCore::start: Insufficient lender deposit");
+    });
+
+    it("gas", async () => {
+      const {
+        mockAssetWrapper,
+        loanCore,
+        mockERC20,
+        loanId,
+        terms: { collateralTokenId, principal },
+        borrower,
+        lender,
+      } = await setupLoan();
+
+      await mockAssetWrapper
+        .connect(borrower)
+        .transferFrom(await borrower.getAddress(), loanCore.address, collateralTokenId);
+      await mockERC20.connect(lender).mint(loanCore.address, principal);
+
+      const tx = await loanCore
+        .connect(borrower)
+        .startLoan(await lender.getAddress(), await borrower.getAddress(), loanId);
+      const receipt = await tx.wait();
+      const gasUsed = receipt.gasUsed;
+      expect(gasUsed.toString()).to.equal("297363");
+    });
+  });
+
+  describe("Repay Loan", function () {
+    interface RepayLoanState extends TestContext {
+      loanId: BigNumber;
+      terms: LoanTerms;
+      borrower: Signer;
+      lender: Signer;
+    }
+
+    const setupLoan = async (context?: TestContext, inputTerms?: Partial<LoanTerms>): Promise<RepayLoanState> => {
+      context = context || (await setupTestContext());
+
+      const { mockAssetWrapper, mockERC20, loanCore, user: borrower, other: lender } = context;
+      const collateralTokenId = await mintERC721(mockAssetWrapper, borrower);
+      const terms = createLoanTerms(mockERC20.address, { collateralTokenId, ...inputTerms });
+      const loanId = await createLoan(loanCore, borrower, terms);
+      await mockAssetWrapper
+        .connect(borrower)
+        .transferFrom(await borrower.getAddress(), loanCore.address, collateralTokenId);
+      await mockERC20.connect(lender).mint(loanCore.address, terms.principal);
+
+      await expect(loanCore.connect(borrower).startLoan(await lender.getAddress(), await borrower.getAddress(), loanId))
+        .to.emit(loanCore, "LoanStarted")
+        .withArgs(loanId, await lender.getAddress(), await borrower.getAddress());
+
+      return { ...context, loanId, terms, borrower, lender };
+    };
+
+    it("should successfully repay loan", async () => {
+      const { mockERC20, loanId, loanCore, user: borrower, terms } = await setupLoan();
+      await mockERC20.connect(borrower).mint(loanCore.address, terms.principal.add(terms.interest));
+
+      await expect(loanCore.connect(borrower).repay(loanId)).to.emit(loanCore, "LoanRepaid").withArgs(loanId);
+    });
+
+    it("should fail if the loan does not exist", async () => {
+      const { loanCore, user: borrower } = await setupLoan();
+      const loanId = BigNumber.from("123412341324");
+      await expect(loanCore.connect(borrower).repay(loanId)).to.be.revertedWith("LoanCore::repay: Invalid loan state");
+    });
+
+    it("should fail if the loan is not active", async () => {
+      const { mockAssetWrapper, loanCore, user: borrower, terms } = await setupLoan();
+      const collateralTokenId = await mintERC721(mockAssetWrapper, borrower);
+      terms.collateralTokenId = collateralTokenId;
+      const loanId = await createLoan(loanCore, borrower, terms);
+      await expect(loanCore.connect(borrower).repay(loanId)).to.be.revertedWith("LoanCore::repay: Invalid loan state");
+    });
+
+    it("should fail if the loan is already repaid", async () => {
+      const { mockERC20, loanId, loanCore, user: borrower, terms } = await setupLoan();
+      await mockERC20.connect(borrower).mint(loanCore.address, terms.principal.add(terms.interest));
+
+      await loanCore.connect(borrower).repay(loanId);
+      await expect(loanCore.connect(borrower).repay(loanId)).to.be.revertedWith("LoanCore::repay: Invalid loan state");
+    });
+
+    it("should fail if the loan is already claimed", async () => {
+      const { mockERC20, loanId, loanCore, user: borrower, terms } = await setupLoan(undefined, {
+        dueDate: await blockchainTime.secondsFromNow(1000),
+      });
+      await mockERC20.connect(borrower).mint(loanCore.address, terms.principal.add(terms.interest));
+
+      await blockchainTime.increaseTime(1001);
+
+      await loanCore.connect(borrower).claim(loanId);
+      await expect(loanCore.connect(borrower).repay(loanId)).to.be.revertedWith("LoanCore::repay: Invalid loan state");
+    });
+
+    it("should fail if the loan is expired", async () => {
+      const { loanId, loanCore, user: borrower } = await setupLoan(undefined, {
+        dueDate: await blockchainTime.secondsFromNow(1000),
+      });
+      await blockchainTime.increaseTime(1001);
+
+      await expect(loanCore.connect(borrower).repay(loanId)).to.be.revertedWith("LoanCore::repay: Loan expired");
+    });
+
+    it("should fail if the debt was not repaid", async () => {
+      const { loanId, loanCore, user: borrower } = await setupLoan();
+
+      await expect(loanCore.connect(borrower).repay(loanId)).to.be.revertedWith(
+        "LoanCore::repay: Insufficient repayment",
+      );
+    });
+
+    it("should fail if the debt was not repaid in full", async () => {
+      const { mockERC20, loanId, loanCore, user: borrower, terms } = await setupLoan();
+      await mockERC20.connect(borrower).mint(loanCore.address, terms.principal.sub(1));
+
+      await expect(loanCore.connect(borrower).repay(loanId)).to.be.revertedWith(
+        "LoanCore::repay: Insufficient repayment",
+      );
+    });
+
+    it("should fail if the interest was not paid in full", async () => {
+      const { mockERC20, loanId, loanCore, user: borrower, terms } = await setupLoan();
+      await mockERC20.connect(borrower).mint(loanCore.address, terms.principal.add(terms.interest).sub(1));
+
+      await expect(loanCore.connect(borrower).repay(loanId)).to.be.revertedWith(
+        "LoanCore::repay: Insufficient repayment",
+      );
+    });
+
+    it("gas", async () => {
+      const { mockERC20, loanId, loanCore, user: borrower, terms } = await setupLoan();
+      await mockERC20.connect(borrower).mint(loanCore.address, terms.principal.add(terms.interest));
+
+      const tx = await loanCore.connect(borrower).repay(loanId);
+      const receipt = await tx.wait();
+      const gasUsed = receipt.gasUsed;
+      expect(gasUsed.toString()).to.equal("108154");
+    });
+  });
+
+  describe("Claim Loan", async function () {
+    interface RepayLoanState extends TestContext {
+      loanId: BigNumber;
+      terms: LoanTerms;
+      borrower: Signer;
+      lender: Signer;
+    }
+
+    const setupLoan = async (context?: TestContext, inputTerms?: Partial<LoanTerms>): Promise<RepayLoanState> => {
+      context = context || (await setupTestContext());
+
+      const { mockAssetWrapper, mockERC20, loanCore, user: borrower, other: lender } = context;
+      const collateralTokenId = await mintERC721(mockAssetWrapper, borrower);
+      const terms = createLoanTerms(mockERC20.address, { collateralTokenId, ...inputTerms });
+      const loanId = await createLoan(loanCore, borrower, terms);
+      await mockAssetWrapper
+        .connect(borrower)
+        .transferFrom(await borrower.getAddress(), loanCore.address, collateralTokenId);
+      await mockERC20.connect(lender).mint(loanCore.address, terms.principal);
+
+      await expect(loanCore.connect(borrower).startLoan(await lender.getAddress(), await borrower.getAddress(), loanId))
+        .to.emit(loanCore, "LoanStarted")
+        .withArgs(loanId, await lender.getAddress(), await borrower.getAddress());
+
+      return { ...context, loanId, terms, borrower, lender };
+    };
+
+    it("should successfully claim loan", async () => {
+      const { mockERC20, loanId, loanCore, user: borrower, terms } = await setupLoan(undefined, {
+        dueDate: await blockchainTime.secondsFromNow(1000),
+      });
+      await mockERC20.connect(borrower).mint(loanCore.address, terms.principal.add(terms.interest));
+
+      await blockchainTime.increaseTime(1001);
+
+      await expect(loanCore.connect(borrower).claim(loanId)).to.emit(loanCore, "LoanClaimed").withArgs(loanId);
+    });
+
+    it("should fail if loan doesnt exist", async () => {
+      const { loanCore, user: borrower } = await setupLoan();
+      const loanId = BigNumber.from("123412341324");
+      await expect(loanCore.connect(borrower).claim(loanId)).to.be.revertedWith("LoanCore::claim: Invalid loan state");
+    });
+
+    it("should fail if the loan is not active", async () => {
+      const { mockAssetWrapper, loanCore, user: borrower, terms } = await setupLoan();
+      const collateralTokenId = await mintERC721(mockAssetWrapper, borrower);
+      terms.collateralTokenId = collateralTokenId;
+      const loanId = await createLoan(loanCore, borrower, terms);
+      await expect(loanCore.connect(borrower).claim(loanId)).to.be.revertedWith("LoanCore::claim: Invalid loan state");
+    });
+
+    it("should fail if the loan is already repaid", async () => {
+      const { mockERC20, loanId, loanCore, user: borrower, terms } = await setupLoan();
+      await mockERC20.connect(borrower).mint(loanCore.address, terms.principal.add(terms.interest));
+
+      await loanCore.connect(borrower).repay(loanId);
+      await expect(loanCore.connect(borrower).claim(loanId)).to.be.revertedWith("LoanCore::claim: Invalid loan state");
+    });
+
+    it("should fail if the loan is already claimed", async () => {
+      const { mockERC20, loanId, loanCore, user: borrower, terms } = await setupLoan(undefined, {
+        dueDate: await blockchainTime.secondsFromNow(1000),
+      });
+      await mockERC20.connect(borrower).mint(loanCore.address, terms.principal.add(terms.interest));
+
+      await blockchainTime.increaseTime(1001);
+
+      await loanCore.connect(borrower).claim(loanId);
+      await expect(loanCore.connect(borrower).claim(loanId)).to.be.revertedWith("LoanCore::claim: Invalid loan state");
+    });
+
+    it("should fail if the loan is not expired", async () => {
+      const { mockERC20, loanId, loanCore, user: borrower, terms } = await setupLoan();
+      await mockERC20.connect(borrower).mint(loanCore.address, terms.principal.add(terms.interest));
+
+      await expect(loanCore.connect(borrower).claim(loanId)).to.be.revertedWith("LoanCore::claim: Loan not expired");
+    });
+
+    it("gas", async () => {
+      const { mockERC20, loanId, loanCore, user: borrower, terms } = await setupLoan(undefined, {
+        dueDate: await blockchainTime.secondsFromNow(1000),
+      });
+      await mockERC20.connect(borrower).mint(loanCore.address, terms.principal.add(terms.interest));
+
+      await blockchainTime.increaseTime(1001);
+
+      const tx = await loanCore.connect(borrower).claim(loanId);
+      const receipt = await tx.wait();
+      const gasUsed = receipt.gasUsed;
+      expect(gasUsed.toString()).to.equal("85061");
+    });
+  });
+});

--- a/test/utils/erc721.ts
+++ b/test/utils/erc721.ts
@@ -1,16 +1,14 @@
 import { expect } from "chai";
-import { Signer } from "ethers";
+import { Signer, BigNumber } from "ethers";
 import { MockERC721 } from "../../typechain/MockERC721";
 
 export const ZERO_ADDRESS = "0x0000000000000000000000000000000000000000";
 
 /**
- * Mint tokens for `to`
+ * Mint a token for `to`
  */
-export const mint = async (token: MockERC721, to: Signer): Promise<string> => {
-  const address = await to.getAddress();
-
-  const tx = await token.mint(address);
+export const mint = async (token: MockERC721, to: Signer): Promise<BigNumber> => {
+  const tx = await token.mint(await to.getAddress());
   const receipt = await tx.wait();
 
   if (receipt && receipt.events && receipt.events.length === 1 && receipt.events[0].args) {
@@ -23,7 +21,12 @@ export const mint = async (token: MockERC721, to: Signer): Promise<string> => {
 /**
  * approve `amount` tokens for `to` from `from`
  */
-export const approve = async (token: MockERC721, sender: Signer, toAddress: string, tokenId: string): Promise<void> => {
+export const approve = async (
+  token: MockERC721,
+  sender: Signer,
+  toAddress: string,
+  tokenId: BigNumber,
+): Promise<void> => {
   const senderAddress = await sender.getAddress();
   expect(await token.getApproved(tokenId)).to.not.equal(toAddress);
 

--- a/test/utils/time.ts
+++ b/test/utils/time.ts
@@ -1,0 +1,14 @@
+import hre from "hardhat";
+
+export class BlockchainTime {
+  async secondsFromNow(secondsFromNow: number): Promise<number> {
+    const res = await hre.network.provider.send("eth_getBlockByNumber", ["latest", false]);
+    const timestamp = parseInt(res.timestamp, 16);
+    return timestamp + secondsFromNow;
+  }
+
+  async increaseTime(seconds: number): Promise<void> {
+    await hre.network.provider.send("evm_increaseTime", [seconds]);
+    await hre.network.provider.send("evm_mine");
+  }
+}


### PR DESCRIPTION
This commit adds an implementation of the LoanCore contract. This
implements the core functionality of the PawnFi lending platform
It also adds a full test suite of the LoanCore contract.

There is some functionality that still remains after this PR. The TODO
list can be found in a block comment at the top of LoanCore.sol, as well
as in inline comments throughout