### PR TITLE
PAWN-175: added .env file with dummy mnemonic for solcover & updated …

### DIFF
--- a/.env
+++ b/.env
@@ -1,0 +1,1 @@
+MNEMONIC=testtesttesttest

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -46,3 +46,6 @@ jobs:
 
       - name: Test
         run: yarn test
+
+      - name: Coverage
+        run: yarn coverage

--- a/.solcover.js
+++ b/.solcover.js
@@ -1,9 +1,9 @@
 const shell = require("shelljs");
 
 // The environment variables are loaded in hardhat.config.ts
-const mnemonic = process.env.MNEMONIC;
+let mnemonic = process.env.MNEMONIC;
 if (!mnemonic) {
-  throw new Error("Please set your MNEMONIC in a .env file");
+  mnemonic = "testtesttesttest"
 }
 
 module.exports = {

--- a/README.md
+++ b/README.md
@@ -101,3 +101,14 @@ compiler version is to add the following fields to your VSCode user settings:
 ```
 
 Where of course `v0.8.3+commit.8d00100c` can be replaced with any other version.
+
+## Solidity Coverage Reporting
+
+Solidity Coverage tracks which lines are hit during a test run by instrumenting your contracts and detecting their execution in a coverage-enabled EVM. Coverage reports are produced under ./coverage and configuration lives in .solcover.js.
+[Solcover](https://github.com/sc-forks/solidity-coverage)
+
+Run Coverage instrumentation:
+
+```sh
+$ yarn coverage
+```


### PR DESCRIPTION
This PR adds global environment variables to `.env`, in particular a dummy `MNEMONIC`, which [solcover](https://github.com/sc-forks/solidity-coverage) depends on in `solcover.js`.

To run coverage reporting locally
```sh
yarn compile && yarn coverage
```
Produces artifacts in `./coverage`, one for each `.sol` file in project and then an `index.html` summarizing coverage results.

![Screen Shot 2021-06-04 at 10 09 57 AM](https://user-images.githubusercontent.com/1355694/120839233-8ae63c00-c51d-11eb-9095-3292f082416e.png)

![Screen Shot 2021-06-04 at 10 10 06 AM](https://user-images.githubusercontent.com/1355694/120839256-90dc1d00-c51d-11eb-9ba8-3c3cf4e18850.png)

Future PR's should integrate coverage reporting with CI and tune the plethora of [options](https://github.com/sc-forks/solidity-coverage) to our needs.

Update: Added coverage invocation in 676402f4c0d26c01f5be2443369bf1ef7328a659 to github test workflow.
Update: Added default mnemonic in lieu of throwing an error in `.solcover.js` and squashed commits.