### PR TITLE
fix: circular dependency

### DIFF
--- a/contracts/PromissoryNote.sol
+++ b/contracts/PromissoryNote.sol
@@ -34,32 +34,21 @@ contract PromissoryNote is Context, AccessControlEnumerable, ERC721, ERC721Enume
     bytes32 public constant PAUSER_ROLE = keccak256("PAUSER_ROLE");
     bytes32 public constant MINTER_ROLE = keccak256("MINTER_ROLE");
     Counters.Counter private _tokenIdTracker;
-    address public loanCore;
 
     /**
      * @dev Creates the borrowor note contract linked to a specific loan core
      * The loan core reference is non-upgradeable
      * See (_setURI).
-     * Grants `PAUSER_ROLE`, `MINTER_ROLE`, and `BURNER_ROLE` to the specified loanCore-
+     * Grants `PAUSER_ROLE`, `MINTER_ROLE`, and `BURNER_ROLE` to the sender
      * contract, provided it is an instance of LoanCore.
      *
      * Grants `DEFAULT_ADMIN_ROLE` to the account that deploys the contract. Admins
   
      */
 
-    constructor(
-        address loanCore_,
-        string memory name,
-        string memory symbol
-    ) ERC721(name, symbol) {
-        require(loanCore_ != address(0), "loanCore address must be defined");
-
-        _setupRole(BURNER_ROLE, loanCore_);
-
-        loanCore = loanCore_;
-
+    constructor(string memory name, string memory symbol) ERC721(name, symbol) {
+        _setupRole(BURNER_ROLE, _msgSender());
         _setupRole(MINTER_ROLE, _msgSender());
-
         _setupRole(PAUSER_ROLE, _msgSender());
     }
 
@@ -91,11 +80,8 @@ contract PromissoryNote is Context, AccessControlEnumerable, ERC721, ERC721Enume
      *
      *
      */
-    function burn(uint256 loanId, uint256 tokenId) external override {
+    function burn(uint256 tokenId) external override {
         require(hasRole(BURNER_ROLE, _msgSender()), "PromissoryNote: callers is not owner nor approved");
-
-        LoanState status = ILoanCore(loanCore).getLoan(loanId).state;
-        require(status != LoanState.Active, "PromissoryNote: LoanCore attempted to burn an active note");
         _burn(tokenId);
     }
 

--- a/contracts/interfaces/IPromissoryNote.sol
+++ b/contracts/interfaces/IPromissoryNote.sol
@@ -10,5 +10,5 @@ interface IPromissoryNote is IERC721 {
 
     function mint(address to) external;
 
-    function burn(uint256 loanId, uint256 tokenId) external;
+    function burn(uint256 tokenId) external;
 }

--- a/test/Integration.ts
+++ b/test/Integration.ts
@@ -1,0 +1,192 @@
+import { expect } from "chai";
+import hre from "hardhat";
+import { BigNumber, BigNumberish, Signer } from "ethers";
+
+import { AssetWrapper, PromissoryNote, LoanCore, MockERC20 } from "../typechain";
+import { ZERO_ADDRESS } from "./utils/erc20";
+import { BlockchainTime } from "./utils/time";
+import { deploy } from "./utils/contracts";
+
+enum LoanState {
+  DUMMY = 0,
+  Created = 1,
+  Active = 2,
+  Repaid = 3,
+  Defaulted = 4,
+}
+
+const ZERO = hre.ethers.utils.parseUnits("0", 18);
+
+interface LoanTerms {
+  dueDate: BigNumberish;
+  principal: BigNumber;
+  interest: BigNumber;
+  collateralTokenId: BigNumber;
+  payableCurrency: string;
+}
+
+interface TestContext {
+  loanCore: LoanCore;
+  mockERC20: MockERC20;
+  borrowerNote: PromissoryNote;
+  lenderNote: PromissoryNote;
+  assetWrapper: AssetWrapper;
+  user: Signer;
+  other: Signer;
+  signers: Signer[];
+}
+
+describe("Integration", () => {
+  const blockchainTime = new BlockchainTime();
+
+  /**
+   * Sets up a test context, deploying new contracts and returning them for use in a test
+   */
+  const setupTestContext = async (): Promise<TestContext> => {
+    const signers: Signer[] = await hre.ethers.getSigners();
+
+    const borrowerNote = <PromissoryNote>await deploy("PromissoryNote", signers[0], ["Mock BorrowerNote", "MB"]);
+    const lenderNote = <PromissoryNote>await deploy("PromissoryNote", signers[0], ["Mock LenderNote", "ML"]);
+    const assetWrapper = <AssetWrapper>await deploy("AssetWrapper", signers[0], ["Mock AssetWrapper", "MA"]);
+    const loanCore = <LoanCore>(
+      await deploy("LoanCore", signers[0], [borrowerNote.address, lenderNote.address, assetWrapper.address])
+    );
+    const mockERC20 = <MockERC20>await deploy("MockERC20", signers[0], ["Mock ERC20", "MOCK"]);
+
+    return {
+      loanCore,
+      borrowerNote,
+      lenderNote,
+      assetWrapper,
+      mockERC20,
+      user: signers[0],
+      other: signers[1],
+      signers: signers.slice(2),
+    };
+  };
+
+  /**
+   * Create a LoanTerms object using the given parameters, or defaults
+   */
+  const createLoanTerms = (
+    payableCurrency: string,
+    {
+      dueDate = new Date(new Date().getTime() + 3600000).getTime(),
+      principal = hre.ethers.utils.parseEther("100"),
+      interest = hre.ethers.utils.parseEther("1"),
+      collateralTokenId = BigNumber.from(1),
+    }: Partial<LoanTerms> = {},
+  ): LoanTerms => {
+    return {
+      dueDate,
+      principal,
+      interest,
+      collateralTokenId,
+      payableCurrency,
+    };
+  };
+
+  /**
+   * Initialize a new loan, returning the loanId
+   */
+  const createLoan = async (loanCore: LoanCore, user: Signer, terms: LoanTerms): Promise<BigNumber> => {
+    const tx = await loanCore.connect(user).createLoan(terms);
+    const receipt = await tx.wait();
+
+    if (receipt && receipt.events && receipt.events.length === 1 && receipt.events[0].args) {
+      return receipt.events[0].args.loanId;
+    } else {
+      throw new Error("Unable to initialize loan");
+    }
+  };
+
+  const createCnft = async (assetWrapper: AssetWrapper, user: Signer) => {
+    const tx = await assetWrapper.initializeBundle(await user.getAddress());
+    const receipt = await tx.wait();
+    if (receipt && receipt.events && receipt.events.length === 1 && receipt.events[0].args) {
+      return receipt.events[0].args.tokenId;
+    } else {
+      throw new Error("Unable to initialize bundle");
+    }
+  };
+
+  /**
+   * Assert equality between two LoanTerms objects
+   */
+  const assertTermsEquality = (actual: LoanTerms, expected: LoanTerms) => {
+    expect(actual.dueDate).to.equal(expected.dueDate);
+    expect(actual.principal).to.equal(expected.principal);
+    expect(actual.interest).to.equal(expected.interest);
+    expect(actual.collateralTokenId).to.equal(expected.collateralTokenId);
+    expect(actual.payableCurrency).to.equal(expected.payableCurrency);
+  };
+
+  describe("Create Loan", function () {
+    it("should successfully create a loan", async () => {
+      const { loanCore, mockERC20, assetWrapper, user } = await setupTestContext();
+      const collateralTokenId = await createCnft(assetWrapper, user);
+      const terms = createLoanTerms(mockERC20.address, { collateralTokenId });
+
+      const loanId = await createLoan(loanCore, user, terms);
+      expect(loanId.gte(ZERO)).to.be.true;
+
+      const storedLoanData = await loanCore.getLoan(loanId);
+      expect(storedLoanData.borrowerNoteId).to.equal(BigNumber.from(0));
+      expect(storedLoanData.lenderNoteId).to.equal(BigNumber.from(0));
+      expect(storedLoanData.state).to.equal(LoanState.Created);
+      assertTermsEquality(storedLoanData.terms, terms);
+    });
+
+    it("should emit the LoanCreated event", async () => {
+      const { loanCore, mockERC20, assetWrapper, user } = await setupTestContext();
+      const collateralTokenId = await createCnft(assetWrapper, user);
+      const terms = createLoanTerms(mockERC20.address, { collateralTokenId });
+
+      await expect(loanCore.connect(user).createLoan(terms)).to.emit(loanCore, "LoanCreated");
+    });
+
+    it("should successfully create a bunch of loans with different loanIds", async () => {
+      const { loanCore, mockERC20, assetWrapper, user } = await setupTestContext();
+
+      const loanIds = new Set();
+      for (let i = 0; i < 10; i++) {
+        const collateralTokenId = await createCnft(assetWrapper, user);
+        const terms = createLoanTerms(mockERC20.address, { collateralTokenId });
+
+        const loanId = await createLoan(loanCore, user, terms);
+        expect(loanIds.has(loanId)).to.be.false;
+        loanIds.add(loanId);
+      }
+    });
+
+    it("should fail to create a loan with nonexistent collateral", async () => {
+      const { loanCore, mockERC20, user } = await setupTestContext();
+      const terms = createLoanTerms(mockERC20.address);
+
+      await expect(createLoan(loanCore, user, terms)).to.be.revertedWith("ERC721: owner query for nonexistent token");
+    });
+
+    it("should fail to create a loan with passed due date", async () => {
+      const { loanCore, mockERC20, assetWrapper, user } = await setupTestContext();
+      const collateralTokenId = await createCnft(assetWrapper, user);
+      const terms = createLoanTerms(mockERC20.address, {
+        collateralTokenId,
+        dueDate: await blockchainTime.secondsFromNow(-1000),
+      });
+
+      await expect(createLoan(loanCore, user, terms)).to.be.revertedWith("LoanCore::create: Loan is already expired");
+    });
+
+    it("should fail to create a loan with reused collateral", async () => {
+      const { loanCore, mockERC20, assetWrapper, user } = await setupTestContext();
+      const collateralTokenId = await createCnft(assetWrapper, user);
+      const terms = createLoanTerms(mockERC20.address, { collateralTokenId });
+
+      await createLoan(loanCore, user, terms);
+
+      await expect(createLoan(loanCore, user, terms)).to.be.revertedWith(
+        "LoanCore::create: Collateral token already in use",
+      );
+    });
+  });
+});

--- a/test/LoanCore.ts
+++ b/test/LoanCore.ts
@@ -188,7 +188,7 @@ describe("LoanCore", () => {
       const tx = await loanCore.connect(user).createLoan(terms);
       const receipt = await tx.wait();
       const gasUsed = receipt.gasUsed;
-      expect(gasUsed.toString()).to.equal("176338");
+      expect(gasUsed.toString()).to.equal("195238");
     });
   });
 
@@ -459,7 +459,7 @@ describe("LoanCore", () => {
         .startLoan(await lender.getAddress(), await borrower.getAddress(), loanId);
       const receipt = await tx.wait();
       const gasUsed = receipt.gasUsed;
-      expect(gasUsed.toString()).to.equal("297363");
+      expect(gasUsed.toString()).to.equal("323763");
     });
   });
 
@@ -573,7 +573,7 @@ describe("LoanCore", () => {
       const tx = await loanCore.connect(borrower).repay(loanId);
       const receipt = await tx.wait();
       const gasUsed = receipt.gasUsed;
-      expect(gasUsed.toString()).to.equal("108154");
+      expect(gasUsed.toString()).to.equal("107354");
     });
   });
 
@@ -667,7 +667,7 @@ describe("LoanCore", () => {
       const tx = await loanCore.connect(borrower).claim(loanId);
       const receipt = await tx.wait();
       const gasUsed = receipt.gasUsed;
-      expect(gasUsed.toString()).to.equal("85061");
+      expect(gasUsed.toString()).to.equal("86661");
     });
   });
 });


### PR DESCRIPTION
This commit removes the circular dependency from the promissory note and
loancore by removing the dependency on loancore from P note.
Also adds an integration test to ensure the contracts work with each
other