### PR TITLE
Finish loan core

### DIFF
--- a/contracts/FeeController.sol
+++ b/contracts/FeeController.sol
@@ -19,11 +19,10 @@ import "./interfaces/IFeeController.sol";
  */
 
 contract FeeController is AccessControlEnumerable, IFeeController, Ownable {
-    uint256 private originationFee;
+    // initial fee is 3%
+    uint256 private originationFee = 300;
 
-    constructor(uint256 _originationFee) {
-        originationFee = _originationFee;
-    }
+    constructor() {}
 
     /**
      * @dev Set the origination fee to the given value
@@ -34,8 +33,9 @@ contract FeeController is AccessControlEnumerable, IFeeController, Ownable {
      *
      * - The caller must be the owner of the contract
      */
-    function setOriginationFee(uint256 _originationFee) external onlyOwner override {
+    function setOriginationFee(uint256 _originationFee) external override onlyOwner {
         originationFee = _originationFee;
+        emit UpdateOriginationFee(_originationFee);
     }
 
     /**

--- a/contracts/interfaces/IFeeController.sol
+++ b/contracts/interfaces/IFeeController.sol
@@ -1,6 +1,11 @@
 pragma solidity ^0.8.0;
 
 interface IFeeController {
+    /**
+     * @dev Emitted when origination fee is updated
+     */
+    event UpdateOriginationFee(uint256 _newFee);
+
     function setOriginationFee(uint256 _originationFee) external;
 
     function getOriginationFee() external view returns (uint256);

--- a/contracts/interfaces/ILoanCore.sol
+++ b/contracts/interfaces/ILoanCore.sol
@@ -77,6 +77,11 @@ interface ILoanCore {
     event LoanClaimed(uint256 loanId);
 
     /**
+     * @dev Emitted when fees are claimed by admin
+     */
+    event FeesClaimed(address token, address to, uint256 amount);
+
+    /**
      * @dev Get LoanData by loanId
      */
     function getLoan(uint256 loanId) external view returns (LoanData calldata loanData);

--- a/test/Integration.ts
+++ b/test/Integration.ts
@@ -2,8 +2,7 @@ import { expect } from "chai";
 import hre from "hardhat";
 import { BigNumber, BigNumberish, Signer } from "ethers";
 
-import { AssetWrapper, PromissoryNote, LoanCore, MockERC20 } from "../typechain";
-import { ZERO_ADDRESS } from "./utils/erc20";
+import { AssetWrapper, FeeController, PromissoryNote, LoanCore, MockERC20 } from "../typechain";
 import { BlockchainTime } from "./utils/time";
 import { deploy } from "./utils/contracts";
 
@@ -48,8 +47,16 @@ describe("Integration", () => {
     const borrowerNote = <PromissoryNote>await deploy("PromissoryNote", signers[0], ["Mock BorrowerNote", "MB"]);
     const lenderNote = <PromissoryNote>await deploy("PromissoryNote", signers[0], ["Mock LenderNote", "ML"]);
     const assetWrapper = <AssetWrapper>await deploy("AssetWrapper", signers[0], ["Mock AssetWrapper", "MA"]);
+    const feeController = <FeeController>await deploy("FeeController", signers[0], []);
     const loanCore = <LoanCore>(
-      await deploy("LoanCore", signers[0], [borrowerNote.address, lenderNote.address, assetWrapper.address])
+      await deploy("LoanCore", signers[0], [
+        borrowerNote.address,
+        lenderNote.address,
+        assetWrapper.address,
+        feeController.address,
+        await signers[0].getAddress(),
+        await signers[0].getAddress(),
+      ])
     );
     const mockERC20 = <MockERC20>await deploy("MockERC20", signers[0], ["Mock ERC20", "MOCK"]);
 


### PR DESCRIPTION
This commit finishes the specification for LoanCore. The added features are:
- removed expiry requirement on repay. Borrowers can now repay expired loans as long as the collateral has not yet been claimed by lender
- Use fee controller in LoanCore to fetch the latest fees
- Add access control to LoanCore. Only originationController can call start and create loan, only repaymentController can call repay and claim. The admin (sender who created the contract, or updated admin(s)) can update these permissions if we ever create new controller instances
- Claim fees - The admin can claim fees from the contract
- Add tests for the above