### PR TITLE
fix: circular dependency

### DIFF
--- a/contracts/LoanCore.sol
+++ b/contracts/LoanCore.sol
@@ -42,13 +42,9 @@ contract LoanCore is ILoanCore, AccessControl {
         INote _borrowerNote,
         INote _lenderNote,
         IERC721 _collateralToken,
-        IFeeController _feeController,
-        address _originationController,
-        address _repaymentController
+        IFeeController _feeController
     ) {
         _setupRole(DEFAULT_ADMIN_ROLE, _msgSender());
-        _setupRole(ORIGINATOR_ROLE, _originationController);
-        _setupRole(REPAYER_ROLE, _repaymentController);
 
         borrowerNote = _borrowerNote;
         lenderNote = _lenderNote;

--- a/test/Integration.ts
+++ b/test/Integration.ts
@@ -14,6 +14,9 @@ enum LoanState {
   Defaulted = 4,
 }
 
+const ORIGINATOR_ROLE = "0x59abfac6520ec36a6556b2a4dd949cc40007459bcd5cd2507f1e5cc77b6bc97e";
+const REPAYER_ROLE = "0x9c60024347074fd9de2c1e36003080d22dbc76a41ef87444d21e361bcb39118e";
+
 const ZERO = hre.ethers.utils.parseUnits("0", 18);
 
 interface LoanTerms {
@@ -54,10 +57,11 @@ describe("Integration", () => {
         lenderNote.address,
         assetWrapper.address,
         feeController.address,
-        await signers[0].getAddress(),
-        await signers[0].getAddress(),
       ])
     );
+
+    await loanCore.connect(signers[0]).grantRole(ORIGINATOR_ROLE, await signers[0].getAddress());
+    await loanCore.connect(signers[0]).grantRole(REPAYER_ROLE, await signers[0].getAddress());
     const mockERC20 = <MockERC20>await deploy("MockERC20", signers[0], ["Mock ERC20", "MOCK"]);
 
     return {

--- a/test/LoanCore.ts
+++ b/test/LoanCore.ts
@@ -61,10 +61,11 @@ describe("LoanCore", () => {
         mockLenderNote.address,
         mockAssetWrapper.address,
         feeController.address,
-        await originator.getAddress(),
-        await repayer.getAddress(),
       ])
     );
+
+    await loanCore.connect(signers[0]).grantRole(ORIGINATOR_ROLE, await originator.getAddress());
+    await loanCore.connect(signers[0]).grantRole(REPAYER_ROLE, await repayer.getAddress());
     const mockERC20 = <MockERC20>await deploy("MockERC20", signers[0], ["Mock ERC20", "MOCK"]);
 
     return {


### PR DESCRIPTION
This commit fixes a circular dependency between LoanCore and
origination/repayment controller. Previously, LoanCore took the
addresses of the controllers as a parameter - now it doesn't and the
admin has to explicitly grant the role to the controllers after they
have been deployed