### PR TITLE
rename cnft wnft everywhere

### DIFF
--- a/test/Integration.ts
+++ b/test/Integration.ts
@@ -110,7 +110,7 @@ describe("Integration", () => {
     };
   };
 
-  const createCnft = async (assetWrapper: AssetWrapper, user: SignerWithAddress) => {
+  const createWnft = async (assetWrapper: AssetWrapper, user: SignerWithAddress) => {
     const tx = await assetWrapper.initializeBundle(await user.getAddress());
     const receipt = await tx.wait();
     if (receipt && receipt.events && receipt.events.length === 1 && receipt.events[0].args) {
@@ -124,7 +124,7 @@ describe("Integration", () => {
     it("should successfully create a loan", async () => {
       const { originationController, mockERC20, loanCore, assetWrapper, lender, borrower } = await setupTestContext();
 
-      const bundleId = await createCnft(assetWrapper, borrower);
+      const bundleId = await createWnft(assetWrapper, borrower);
       const loanTerms = createLoanTerms(mockERC20.address, { collateralTokenId: bundleId });
       await mint(mockERC20, lender, loanTerms.principal);
 
@@ -148,10 +148,10 @@ describe("Integration", () => {
         .to.emit(loanCore, "LoanStarted");
     });
 
-    it("should fail to start loan if cNFT is withdrawn", async () => {
+    it("should fail to start loan if wNFT is withdrawn", async () => {
       const { originationController, mockERC20, assetWrapper, lender, borrower } = await setupTestContext();
 
-      const bundleId = await createCnft(assetWrapper, borrower);
+      const bundleId = await createWnft(assetWrapper, borrower);
       const loanTerms = createLoanTerms(mockERC20.address, { collateralTokenId: bundleId });
       await mint(mockERC20, lender, loanTerms.principal);
 
@@ -198,7 +198,7 @@ describe("Integration", () => {
     it("should fail to create a loan with passed due date", async () => {
       const { originationController, mockERC20, assetWrapper, lender, borrower } = await setupTestContext();
 
-      const bundleId = await createCnft(assetWrapper, borrower);
+      const bundleId = await createWnft(assetWrapper, borrower);
       const loanTerms = createLoanTerms(mockERC20.address, {
         collateralTokenId: bundleId,
         dueDate: await blockchainTime.secondsFromNow(-1000),
@@ -232,7 +232,7 @@ describe("Integration", () => {
 
     const initializeLoan = async (context: TestContext): Promise<LoanDef> => {
       const { originationController, mockERC20, assetWrapper, loanCore, lender, borrower } = context;
-      const bundleId = await createCnft(assetWrapper, borrower);
+      const bundleId = await createWnft(assetWrapper, borrower);
       const loanTerms = createLoanTerms(mockERC20.address, { collateralTokenId: bundleId });
       await mint(mockERC20, lender, loanTerms.principal);
 
@@ -332,7 +332,7 @@ describe("Integration", () => {
     const initializeLoan = async (context: TestContext): Promise<LoanDef> => {
       const { originationController, mockERC20, assetWrapper, loanCore, lender, borrower } = context;
       const dueDate = await blockchainTime.secondsFromNow(1000);
-      const bundleId = await createCnft(assetWrapper, borrower);
+      const bundleId = await createWnft(assetWrapper, borrower);
       const loanTerms = createLoanTerms(mockERC20.address, { collateralTokenId: bundleId, dueDate });
       await mint(mockERC20, lender, loanTerms.principal);
 

--- a/test/OriginationController.ts
+++ b/test/OriginationController.ts
@@ -138,7 +138,7 @@ describe("OriginationController", () => {
       ).to.be.revertedWith("Origination: sender not participant");
     });
 
-    it("Reverts if cNFT not approved", async () => {
+    it("Reverts if wNFT not approved", async () => {
       const {
         originationController,
         mockERC20,
@@ -159,7 +159,7 @@ describe("OriginationController", () => {
       );
 
       await approve(mockERC20, lender, originationController.address, loanTerms.principal);
-      // no approval of cNFT token
+      // no approval of wNFT token
       await expect(
         originationController
           .connect(lender)

--- a/test/RepaymentController.ts
+++ b/test/RepaymentController.ts
@@ -32,7 +32,7 @@ describe("RepaymentController", () => {
     const signers: Signer[] = await hre.ethers.getSigners();
     const [deployer, borrower, lender, otherParty] = signers;
 
-    const mockCollateral = <MockERC721>await deploy("MockERC721", deployer, ["Mock Collateral", "McNFT"]);
+    const mockCollateral = <MockERC721>await deploy("MockERC721", deployer, ["Mock Collateral", "MwNFT"]);
     const mockLoanCore = <MockLoanCore>await deploy("MockLoanCore", deployer, []);
 
     const borrowerNoteAddress = await mockLoanCore.borrowerNote();


### PR DESCRIPTION
As part of our renaming of cNFT -> wNFT this PR rightsizes our contracts wherever the former was referenced.

Before the changes in this PR
➜  pawnfi-contracts git:(jt/rename-cnft-wnft) ack -i "cNFT"
test/OriginationController.ts
141:    it("Reverts if cNFT not approved", async () => {
162:      // no approval of cNFT token

test/Integration.ts
113:  const createCnft = async (assetWrapper: AssetWrapper, user: SignerWithAddress) => {
127:      const bundleId = await createCnft(assetWrapper, borrower);
151:    it("should fail to start loan if cNFT is withdrawn", async () => {
154:      const bundleId = await createCnft(assetWrapper, borrower);
201:      const bundleId = await createCnft(assetWrapper, borrower);
235:      const bundleId = await createCnft(assetWrapper, borrower);
335:      const bundleId = await createCnft(assetWrapper, borrower);

test/RepaymentController.ts
35:    const mockCollateral = <MockERC721>await deploy("MockERC721", deployer, ["Mock Collateral", "McNFT"]);


After
```
➜  pawnfi-contracts git:(jt/swap-cnft-for-wnft) ✗ ack -i "cnft"
➜  pawnfi-contracts git:(jt/swap-cnft-for-wnft) ✗ 
```