### PR TITLE
Rollover optimization

### DIFF
--- a/contracts/FlashRollover.sol
+++ b/contracts/FlashRollover.sol
@@ -3,8 +3,8 @@ pragma experimental ABIEncoderV2;
 
 import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 import "@openzeppelin/contracts/token/ERC721/IERC721.sol";
-
 import "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
+import "@openzeppelin/contracts/security/ReentrancyGuard.sol";
 
 import "./external/interfaces/ILendingPool.sol";
 
@@ -26,7 +26,7 @@ import "./interfaces/IFeeController.sol";
  * Full API docs at docs/FlashRollover.md
  *
  */
-contract FlashRollover is IFlashRollover {
+contract FlashRollover is IFlashRollover, ReentrancyGuard {
     using SafeERC20 for IERC20;
 
     /* solhint-disable var-name-mixedcase */
@@ -50,41 +50,32 @@ contract FlashRollover is IFlashRollover {
         bytes32 r,
         bytes32 s
     ) external override {
-        LoanLibrary.LoanData memory loanData = contracts.sourceLoanCore.getLoan(loanId);
-        _validateRollover(loanData, contracts.sourceLoanCore, contracts.targetLoanCore, newLoanTerms);
+        ILoanCore sourceLoanCore = contracts.sourceLoanCore;
+        LoanLibrary.LoanData memory loanData = sourceLoanCore.getLoan(loanId);
+        LoanLibrary.LoanTerms memory loanTerms = loanData.terms;
 
-        uint256 amountDue = loanData.terms.principal + loanData.terms.interest;
+        _validateRollover(sourceLoanCore, contracts.targetLoanCore, loanTerms, newLoanTerms, loanData.borrowerNoteId);
 
         {
             address[] memory assets = new address[](1);
-            assets[0] = loanData.terms.payableCurrency;
+            assets[0] = loanTerms.payableCurrency;
 
             uint256[] memory amounts = new uint256[](1);
-            amounts[0] = amountDue;
+            amounts[0] = loanTerms.principal + loanTerms.interest;
 
             uint256[] memory modes = new uint256[](1);
             modes[0] = 0;
 
-            OperationData memory opData = OperationData({
-                contracts: contracts,
-                loanId: loanId,
-                newLoanTerms: newLoanTerms,
-                v: v,
-                r: r,
-                s: s
-            });
-
-            bytes memory params = abi.encode(opData);
+            bytes memory params = abi.encode(
+                OperationData({ contracts: contracts, loanId: loanId, newLoanTerms: newLoanTerms, v: v, r: r, s: s })
+            );
 
             // Flash loan based on principal + interest
             LENDING_POOL.flashLoan(address(this), assets, amounts, modes, address(this), params, 0);
         }
 
         // Should not have any funds leftover
-        require(
-            IERC20(loanData.terms.payableCurrency).balanceOf(address(this)) == 0,
-            "Leftover balance after flash loan"
-        );
+        require(IERC20(loanTerms.payableCurrency).balanceOf(address(this)) == 0, "leftover balance");
     }
 
     function executeOperation(
@@ -93,17 +84,11 @@ contract FlashRollover is IFlashRollover {
         uint256[] calldata premiums,
         address initiator,
         bytes calldata params
-    ) external override returns (bool) {
-        // TODO: Security check.
-        // Can an attacker use this to drain borrower funds? Feels like maybe
+    ) external override nonReentrant returns (bool) {
+        require(msg.sender == address(LENDING_POOL), "unknown callback sender");
+        require(initiator == address(this), "not initiator");
 
-        require(msg.sender == address(LENDING_POOL), "Unknown lender");
-        require(initiator == address(this), "Not initiator");
-        require(IERC20(assets[0]).balanceOf(address(this)) >= amounts[0], "Did not receive loan funds");
-
-        OperationData memory opData = abi.decode(params, (OperationData));
-
-        return _executeOperation(assets, amounts, premiums, opData);
+        return _executeOperation(assets, amounts, premiums, abi.decode(params, (OperationData)));
     }
 
     function _executeOperation(
@@ -116,7 +101,6 @@ contract FlashRollover is IFlashRollover {
 
         // Get loan details
         LoanLibrary.LoanData memory loanData = opContracts.loanCore.getLoan(opData.loanId);
-        require(loanData.borrowerNoteId != 0, "Cannot find note");
 
         address borrower = opContracts.borrowerNote.ownerOf(loanData.borrowerNoteId);
         address lender = opContracts.lenderNote.ownerOf(loanData.lenderNoteId);
@@ -132,11 +116,11 @@ contract FlashRollover is IFlashRollover {
         IERC20 asset = IERC20(assets[0]);
 
         if (needFromBorrower > 0) {
-            require(asset.balanceOf(borrower) >= needFromBorrower, "Borrower cannot pay");
-            require(asset.allowance(borrower, address(this)) >= needFromBorrower, "Need borrower to approve balance");
+            require(asset.balanceOf(borrower) >= needFromBorrower, "borrower cannot pay");
+            require(asset.allowance(borrower, address(this)) >= needFromBorrower, "lacks borrower approval");
         }
 
-        _repayLoan(opContracts, loanData);
+        _repayLoan(opContracts, loanData, borrower);
         uint256 newLoanId = _initializeNewLoan(opContracts, borrower, lender, loanData.terms.collateralTokenId, opData);
 
         if (leftoverPrincipal > 0) {
@@ -184,13 +168,14 @@ contract FlashRollover is IFlashRollover {
         }
 
         // Either leftoverPrincipal or needFromBorrower should be 0
-
-        require(leftoverPrincipal == 0 || needFromBorrower == 0, "_ensureFunds computation");
+        require(leftoverPrincipal == 0 || needFromBorrower == 0, "funds conflict");
     }
 
-    function _repayLoan(OperationContracts memory contracts, LoanLibrary.LoanData memory loanData) internal {
-        address borrower = contracts.borrowerNote.ownerOf(loanData.borrowerNoteId);
-
+    function _repayLoan(
+        OperationContracts memory contracts,
+        LoanLibrary.LoanData memory loanData,
+        address borrower
+    ) internal {
         // Take BorrowerNote from borrower
         // Must be approved for withdrawal
         contracts.borrowerNote.transferFrom(borrower, address(this), loanData.borrowerNoteId);
@@ -207,7 +192,7 @@ contract FlashRollover is IFlashRollover {
         // contract now has asset wrapper but has lost funds
         require(
             contracts.assetWrapper.ownerOf(loanData.terms.collateralTokenId) == address(this),
-            "Post-loan: not owner of collateral"
+            "collateral ownership"
         );
     }
 
@@ -254,24 +239,21 @@ contract FlashRollover is IFlashRollover {
     }
 
     function _validateRollover(
-        LoanLibrary.LoanData memory loanData,
-        ILoanCore loanCore,
+        ILoanCore sourceLoanCore,
         ILoanCore targetLoanCore,
-        LoanLibrary.LoanTerms calldata newLoanTerms
+        LoanLibrary.LoanTerms memory sourceLoanTerms,
+        LoanLibrary.LoanTerms calldata newLoanTerms,
+        uint256 borrowerNoteId
     ) internal {
-        uint256 borrowerNoteId = loanData.borrowerNoteId;
+        require(sourceLoanCore.borrowerNote().ownerOf(borrowerNoteId) == msg.sender, "caller not borrower");
 
-        IERC721 borrowerNote = loanCore.borrowerNote();
-        address borrower = borrowerNote.ownerOf(borrowerNoteId);
-        require(borrower == msg.sender, "Rollover: borrower only");
+        require(newLoanTerms.payableCurrency == sourceLoanTerms.payableCurrency, "currency mismatch");
 
-        LoanLibrary.LoanTerms memory terms = loanData.terms;
+        require(newLoanTerms.collateralTokenId == sourceLoanTerms.collateralTokenId, "collateral mismatch");
 
-        require(newLoanTerms.payableCurrency == terms.payableCurrency, "Currency mismatch");
-        require(newLoanTerms.collateralTokenId == terms.collateralTokenId, "Collateral mismatch");
         require(
-            address(loanCore.collateralToken()) == address(targetLoanCore.collateralToken()),
-            "Non-compatible AssetWrapper"
+            address(sourceLoanCore.collateralToken()) == address(targetLoanCore.collateralToken()),
+            "non-compatible AssetWrapper"
         );
     }
 }

--- a/contracts/interfaces/IFlashRollover.sol
+++ b/contracts/interfaces/IFlashRollover.sol
@@ -29,6 +29,8 @@ interface IFlashRollover is IFlashLoanReceiver {
 
     event Migration(address indexed oldLoanCore, address indexed newLoanCore, uint256 newLoanId);
 
+    event SetOwner(address owner);
+
     /**
      * The contract references needed to roll
      * over the loan. Other dependent contracts
@@ -85,4 +87,8 @@ interface IFlashRollover is IFlashLoanReceiver {
         bytes32 r,
         bytes32 s
     ) external;
+
+    function setOwner(address _owner) external;
+
+    function flushToken(IERC20 token, address to) external;
 }

--- a/docs/FlashRollover.md
+++ b/docs/FlashRollover.md
@@ -219,6 +219,26 @@ contain all needed terms and signature information to start a loan with the
 `OriginationController`. Once the loan is initialized, the borrower
 note will be transferred to `borrower`.
 
+### `setOwner(address _owner)` _(external)_
+
+Sets a contract owner. The owner is the only party allowed to call `flushToken`.
+
+Requirements:
+- Must be called by current `owner`.
+
+Emits a `SetOwner` event.
+
+### `flushToken(IERC20 token, address to)` _(external)_
+
+Send any ERC20 token balance held within the contract to a specified
+address. Needed because balance checks for flash rollover assume
+a starting and ending balance of 0 tokens. This prevents the contract
+being frozen by a non-zero token balance (either unintentionally or
+from a griefing attack).
+
+Requirements:
+- Must be called by current `owner`.
+
 ## Events
 
 ### `Rollover`
@@ -245,3 +265,7 @@ event Migration(
 ```
 
 Emitted when a loan rollover migrates a loan from one instance of `LoanCore` to another.
+
+### `SetOwner(address owner)`
+
+Emitted when the contract owner is changed.

--- a/docs/FlashRollover.md
+++ b/docs/FlashRollover.md
@@ -224,6 +224,7 @@ note will be transferred to `borrower`.
 Sets a contract owner. The owner is the only party allowed to call `flushToken`.
 
 Requirements:
+
 - Must be called by current `owner`.
 
 Emits a `SetOwner` event.
@@ -237,6 +238,7 @@ being frozen by a non-zero token balance (either unintentionally or
 from a griefing attack).
 
 Requirements:
+
 - Must be called by current `owner`.
 
 ## Events

--- a/test/FlashRollover.ts
+++ b/test/FlashRollover.ts
@@ -1113,23 +1113,21 @@ describe("FlashRollover", () => {
             it("does not allow a non-owner to set a new owner", async () => {
                 const { borrower } = ctx;
 
-                await expect(
-                    flashRollover.connect(borrower).setOwner(borrower.address)
-                ).to.be.revertedWith("not owner");
+                await expect(flashRollover.connect(borrower).setOwner(borrower.address)).to.be.revertedWith(
+                    "not owner",
+                );
             });
 
             it("sets a new owner", async () => {
                 // Check transaction emits SetOwner event
                 const { admin, borrower } = ctx;
 
-                await expect(
-                    flashRollover.connect(admin).setOwner(borrower.address)
-                ).to.emit(flashRollover, "SetOwner").withArgs(borrower.address);
+                await expect(flashRollover.connect(admin).setOwner(borrower.address))
+                    .to.emit(flashRollover, "SetOwner")
+                    .withArgs(borrower.address);
 
                 // Check old owner privileges are revoked
-                await expect(
-                    flashRollover.connect(admin).setOwner(admin.address)
-                ).to.be.revertedWith("not owner");
+                await expect(flashRollover.connect(admin).setOwner(admin.address)).to.be.revertedWith("not owner");
             });
         });
 
@@ -1145,18 +1143,18 @@ describe("FlashRollover", () => {
             it("does not a allow a non-owner to flush tokens", async () => {
                 const {
                     borrower,
-                    common: { mockERC20 }
+                    common: { mockERC20 },
                 } = ctx;
 
                 await expect(
-                    flashRollover.connect(borrower).flushToken(mockERC20.address, borrower.address)
+                    flashRollover.connect(borrower).flushToken(mockERC20.address, borrower.address),
                 ).to.be.revertedWith("not owner");
             });
 
             it("flushes a token from the contract", async () => {
                 const {
                     admin,
-                    common: { mockERC20 }
+                    common: { mockERC20 },
                 } = ctx;
 
                 const adminStartBalance = await mockERC20.balanceOf(admin.address);
@@ -1165,7 +1163,7 @@ describe("FlashRollover", () => {
                 const tokenAmount = ethers.utils.parseEther("10");
                 await mockERC20.mint(flashRollover.address, tokenAmount);
 
-                await flashRollover.flushToken(mockERC20.address, admin.address)
+                await flashRollover.flushToken(mockERC20.address, admin.address);
 
                 const adminEndBalance = await mockERC20.balanceOf(admin.address);
 

--- a/test/FlashRollover.ts
+++ b/test/FlashRollover.ts
@@ -277,7 +277,7 @@ describe("FlashRollover", () => {
 
             await expect(
                 flashRollover.connect(admin).rolloverLoan(contracts, loanId, loanTerms, v, r, s),
-            ).to.be.revertedWith("Rollover: borrower only");
+            ).to.be.revertedWith("caller not borrower");
         });
 
         it("should revert if new loan currency does not match old loan", async () => {
@@ -302,7 +302,7 @@ describe("FlashRollover", () => {
 
             await expect(
                 flashRollover.connect(borrower).rolloverLoan(contracts, loanId, loanTerms, v, r, s),
-            ).to.be.revertedWith("Currency mismatch");
+            ).to.be.revertedWith("currency mismatch");
         });
 
         it("should revert if new loan collateral token does not match old loan", async () => {
@@ -332,7 +332,7 @@ describe("FlashRollover", () => {
 
             await expect(
                 flashRollover.connect(borrower).rolloverLoan(contracts, loanId, loanTerms, v, r, s),
-            ).to.be.revertedWith("Collateral mismatch");
+            ).to.be.revertedWith("collateral mismatch");
         });
 
         it("should revert if has not approved flash loan balance", async () => {
@@ -364,7 +364,7 @@ describe("FlashRollover", () => {
 
             await expect(
                 flashRollover.connect(borrower).rolloverLoan(contracts, loanId, loanTerms, v, r, s),
-            ).to.be.revertedWith("Need borrower to approve balance");
+            ).to.be.revertedWith("lacks borrower approval");
         });
 
         it("should revert if borrower cannot cover flash loan balance", async () => {
@@ -399,7 +399,7 @@ describe("FlashRollover", () => {
 
             await expect(
                 flashRollover.connect(borrower).rolloverLoan(contracts, loanId, loanTerms, v, r, s),
-            ).to.be.revertedWith("Borrower cannot pay");
+            ).to.be.revertedWith("borrower cannot pay");
         });
 
         it("should revert if new loan terms do not match signature", async () => {
@@ -619,7 +619,7 @@ describe("FlashRollover", () => {
             const tx = await flashRollover.connect(borrower).rolloverLoan(contracts, loanId, loanTerms, v, r, s);
             const receipt = await tx.wait();
             const gasUsed = receipt.gasUsed;
-            expect(gasUsed.toString()).to.equal("883268");
+            expect(gasUsed.toString()).to.equal("885260");
         });
     });
 
@@ -691,7 +691,7 @@ describe("FlashRollover", () => {
 
             await expect(
                 flashRollover.connect(admin).rolloverLoan(contracts, loanId, loanTerms, v, r, s),
-            ).to.be.revertedWith("Rollover: borrower only");
+            ).to.be.revertedWith("caller not borrower");
         });
 
         it("should revert if new loan currency does not match old loan", async () => {
@@ -716,7 +716,7 @@ describe("FlashRollover", () => {
 
             await expect(
                 flashRollover.connect(borrower).rolloverLoan(contracts, loanId, loanTerms, v, r, s),
-            ).to.be.revertedWith("Currency mismatch");
+            ).to.be.revertedWith("currency mismatch");
         });
 
         it("should revert if target loanCore does not use same AssetWrapper", async () => {
@@ -764,7 +764,7 @@ describe("FlashRollover", () => {
 
             await expect(
                 flashRollover.connect(borrower).rolloverLoan(contracts, loanId, loanTerms, v, r, s),
-            ).to.be.revertedWith("Non-compatible AssetWrapper");
+            ).to.be.revertedWith("non-compatible AssetWrapper");
         });
 
         it("should revert if new loan collateral token does not match old loan", async () => {
@@ -795,7 +795,7 @@ describe("FlashRollover", () => {
 
             await expect(
                 flashRollover.connect(borrower).rolloverLoan(contracts, loanId, loanTerms, v, r, s),
-            ).to.be.revertedWith("Collateral mismatch");
+            ).to.be.revertedWith("collateral mismatch");
         });
 
         it("should revert if borrower has not approved flash loan balance", async () => {
@@ -828,7 +828,7 @@ describe("FlashRollover", () => {
 
             await expect(
                 flashRollover.connect(borrower).rolloverLoan(contracts, loanId, loanTerms, v, r, s),
-            ).to.be.revertedWith("Need borrower to approve balance");
+            ).to.be.revertedWith("lacks borrower approval");
         });
 
         it("should revert if borrower cannot cover flash loan balance", async () => {
@@ -864,7 +864,7 @@ describe("FlashRollover", () => {
 
             await expect(
                 flashRollover.connect(borrower).rolloverLoan(contracts, loanId, loanTerms, v, r, s),
-            ).to.be.revertedWith("Borrower cannot pay");
+            ).to.be.revertedWith("borrower cannot pay");
         });
 
         it("should revert if new loan terms do not match signature", async () => {
@@ -1096,7 +1096,7 @@ describe("FlashRollover", () => {
             const tx = await flashRollover.connect(borrower).rolloverLoan(contracts, loanId, loanTerms, v, r, s);
             const receipt = await tx.wait();
             const gasUsed = receipt.gasUsed;
-            expect(gasUsed.toString()).to.equal("1094509");
+            expect(gasUsed.toString()).to.equal("1096502");
         });
     });
 });


### PR DESCRIPTION
Do a couple small fixes to optimize the rollover contract.

* Make `executeOperation` non-reentrant
* Check 0 balances before and after flash rollover operation.
* Shave off some gas in a few places to offset the reentrancy check.