### PR TITLE
feat: add claim functionality to vault

### DIFF
--- a/contracts/LoanCore.sol
+++ b/contracts/LoanCore.sol
@@ -8,6 +8,7 @@ import "@openzeppelin/contracts/token/ERC721/IERC721.sol";
 import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 import "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
 import "@openzeppelin/contracts/utils/Counters.sol";
+import "./interfaces/ICallDelegator.sol";
 import "./interfaces/IPromissoryNote.sol";
 import "./interfaces/IAssetVault.sol";
 import "./interfaces/IFeeController.sol";
@@ -18,7 +19,7 @@ import "./PromissoryNote.sol";
 /**
  * @dev LoanCore contract - core contract for creating, repaying, and claiming collateral for PawnFi loans
  */
-contract LoanCore is ILoanCore, AccessControl, Pausable {
+contract LoanCore is ILoanCore, AccessControl, Pausable, ICallDelegator {
     using Counters for Counters.Counter;
     using SafeMath for uint256;
     using SafeERC20 for IERC20;
@@ -232,5 +233,27 @@ contract LoanCore is ILoanCore, AccessControl, Pausable {
      */
     function unpause() external onlyRole(DEFAULT_ADMIN_ROLE) {
         _unpause();
+    }
+
+    /**
+     * @inheritdoc ICallDelegator
+     */
+    function canCallOn(address caller, address vault) external view override returns (bool) {
+        // if the collateral is not currently being used in a loan, disallow
+        if (!collateralInUse[uint256(uint160(vault))]) {
+            return false;
+        }
+
+        for (uint256 i = 0; i < borrowerNote.balanceOf(caller); i++) {
+            uint256 borrowerNoteId = borrowerNote.tokenOfOwnerByIndex(caller, i);
+            uint256 loanId = borrowerNote.loanIdByNoteId(borrowerNoteId);
+            // if the borrower is currently borrowing against this vault,
+            // return true
+            if (loans[loanId].terms.collateralTokenId == uint256(uint160(vault))) {
+                return true;
+            }
+        }
+
+        return false;
     }
 }

--- a/contracts/interfaces/IAssetVault.sol
+++ b/contracts/interfaces/IAssetVault.sol
@@ -1,4 +1,5 @@
 // SPDX-License-Identifier: MIT
+import "./ICallWhitelist.sol";
 
 pragma solidity ^0.8.0;
 
@@ -38,9 +39,15 @@ interface IAssetVault {
     event WithdrawETH(address indexed operator, address indexed recipient, uint256 amount);
 
     /**
-     * @dev Sets up the vault
+     * @dev Emitted when an external call is made from the vault
      */
-    function initialize() external;
+    event Call(address indexed operator, address indexed to, bytes data);
+
+    /**
+     * @dev Sets up the vault
+     * @param _whitelist The whitelist contract which decides what external calls are valid
+     */
+    function initialize(address _whitelist) external;
 
     /**
      * @dev Return true if withdrawing is enabled on the vault
@@ -49,6 +56,11 @@ interface IAssetVault {
      *  as the held assets may be withdrawn without notice, i.e. to frontrun a deposit
      */
     function withdrawEnabled() external view returns (bool);
+
+    /**
+     * @dev Return the contract being used to whitelist function calls
+     */
+    function whitelist() external view returns (ICallWhitelist);
 
     /**
      * @dev Enables withdrawals on the vault
@@ -118,4 +130,19 @@ interface IAssetVault {
      * - The caller must be the owner
      */
     function withdrawETH(address to) external;
+
+    /**
+     * @dev Call a function on an external contract
+     * @dev This is intended for claiming airdrops while the vault is being used as collateral
+     * @param to The contract address to call
+     * @param data The data to call the contract with
+     *
+     * Requirements:
+     *
+     * - The vault must be in closed state
+     * - The caller must either be the owner, or the owner must have explicitly
+     *  delegated this ability to the caller through ICallDelegator interface
+     * - The call must be in the whitelist
+     */
+    function call(address to, bytes memory data) external;
 }

--- a/contracts/interfaces/ICallDelegator.sol
+++ b/contracts/interfaces/ICallDelegator.sol
@@ -1,0 +1,18 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity ^0.8.0;
+
+/**
+ * @dev Interface for a vault owner to delegate call ability to another entity
+ *   Useful in the case where a vault is being used as collateral for a loan
+ *   and the borrower wants to claim an airdrop
+ */
+interface ICallDelegator {
+    /**
+     * @dev Return true if the caller is allowed to call functions on the given vault
+     * @param caller The user that wants to call a function
+     * @param vault The vault that the caller wants to call a function on
+     * @return true if allowed, else false
+     */
+    function canCallOn(address caller, address vault) external view returns (bool);
+}

--- a/contracts/interfaces/ICallWhitelist.sol
+++ b/contracts/interfaces/ICallWhitelist.sol
@@ -1,0 +1,41 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity ^0.8.0;
+
+/**
+ * @dev Interface for a call whitelist contract which
+ * whitelists certain functions on certain contracts to call
+ */
+interface ICallWhitelist {
+    /**
+     * @dev Emitted when a new call is whitelisted
+     */
+    event CallAdded(address operator, address callee, bytes4 selector);
+
+    /**
+     * @dev Emitted when a call is removed from the whitelist
+     */
+    event CallRemoved(address operator, address callee, bytes4 selector);
+
+    /**
+     * @dev Return true if the given function on the given callee is whitelisted
+     * @param callee The contract that is intended to be called
+     * @param selector The function selector that is intended to be called
+     * @return true if whitelisted, else false
+     */
+    function isWhitelisted(address callee, bytes4 selector) external view returns (bool);
+
+    /**
+     * @dev Add the given callee and selector to the whitelist
+     * @param callee The contract to whitelist
+     * @param selector The function selector to whitelist
+     */
+    function add(address callee, bytes4 selector) external;
+
+    /**
+     * @dev Remove the given callee and selector from the whitelist
+     * @param callee The contract to whitelist
+     * @param selector The function selector to whitelist
+     */
+    function remove(address callee, bytes4 selector) external;
+}

--- a/contracts/interfaces/IPromissoryNote.sol
+++ b/contracts/interfaces/IPromissoryNote.sol
@@ -1,8 +1,8 @@
 pragma solidity ^0.8.0;
 
-import "@openzeppelin/contracts/token/ERC721/ERC721.sol";
+import "@openzeppelin/contracts/token/ERC721/extensions/IERC721Enumerable.sol";
 
-interface IPromissoryNote is IERC721 {
+interface IPromissoryNote is IERC721Enumerable {
     // Getter for mapping: mapping(uint256 => uint256) public loanIdByNoteId;
     function loanIdByNoteId(uint256 noteId) external view returns (uint256);
 

--- a/contracts/test/MockCallDelegator.sol
+++ b/contracts/test/MockCallDelegator.sol
@@ -1,0 +1,20 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+import "../interfaces/ICallDelegator.sol";
+
+contract MockCallDelegator is ICallDelegator {
+    bool private canCall;
+
+    /**
+     * @inheritdoc ICallDelegator
+     */
+    function canCallOn(address caller, address vault) external view override returns (bool) {
+        require(caller != vault, "Invalid vault");
+        return canCall;
+    }
+
+    function setCanCall(bool _canCall) external {
+        canCall = _canCall;
+    }
+}

--- a/contracts/test/MockERC721.sol
+++ b/contracts/test/MockERC721.sol
@@ -21,7 +21,7 @@ contract MockERC721 is Context, ERC721Enumerable {
      */
     function mint(address to) external returns (uint256 tokenId) {
         tokenId = _tokenIdTracker.current();
-        _mint(to, tokenId);
+        _mint(to, uint256(uint160(address(this))) + tokenId);
         _tokenIdTracker.increment();
     }
 

--- a/contracts/vault/CallWhitelist.sol
+++ b/contracts/vault/CallWhitelist.sol
@@ -1,0 +1,77 @@
+// SPDX-License-Identifier: GPL-3.0-only
+pragma solidity ^0.8.0;
+
+import "@openzeppelin/contracts/access/Ownable.sol";
+import "../interfaces/ICallWhitelist.sol";
+
+/**
+ * @title CallWhitelist
+ * @notice Whitelist for calls that can be made from a vault
+ * @dev This is intended to allow for "claim" functions to be called
+ *  while vault is being held in escrow as collateral.
+ * @dev Note this contract has admin permissions, which grant the admin
+ *  the ability to add and remove contracts and functions from the whitelist
+ */
+contract CallWhitelist is Ownable, ICallWhitelist {
+    // add some function selectors to the global blacklist
+    // as-in clearly we shouldn't be able to just raw transfer assets out of the vault
+    // without going through the normal process
+    bytes4 private constant ERC20_TRANSFER = 0xa9059cbb;
+    bytes4 private constant ERC20_ERC721_APPROVE = 0x095ea7b3;
+    bytes4 private constant ERC20_ERC721_TRANSFER_FROM = 0x23b872dd;
+
+    bytes4 private constant ERC721_SAFE_TRANSFER_FROM = 0x42842e0e;
+    bytes4 private constant ERC721_SAFE_TRANSFER_FROM_DATA = 0xb88d4fde;
+    bytes4 private constant ERC721_ERC1155_SET_APPROVAL = 0xa22cb465;
+
+    bytes4 private constant ERC1155_SAFE_TRANSFER_FROM = 0xf242432a;
+    bytes4 private constant ERC1155_SAFE_BATCH_TRANSFER_FROM = 0x2eb2c2d6;
+
+    /**
+     * @notice whitelist of callable functions on contracts
+     *  Maps address that can be called to function selectors which can be called on it
+     *  I.e. if we want to call 0x0000 on contract at 0x1111, mapping will have
+     *  whitelist[0x1111][0x0000] = true
+     */
+    mapping(address => mapping(bytes4 => bool)) private whitelist;
+
+    /**
+     * @inheritdoc ICallWhitelist
+     */
+    function isWhitelisted(address callee, bytes4 selector) external view override returns (bool) {
+        return !isBlacklisted(selector) && whitelist[callee][selector];
+    }
+
+    /**
+     * @inheritdoc ICallWhitelist
+     */
+    function add(address callee, bytes4 selector) external override onlyOwner {
+        whitelist[callee][selector] = true;
+        emit CallAdded(msg.sender, callee, selector);
+    }
+
+    /**
+     * @inheritdoc ICallWhitelist
+     */
+    function remove(address callee, bytes4 selector) external override onlyOwner {
+        whitelist[callee][selector] = false;
+        emit CallRemoved(msg.sender, callee, selector);
+    }
+
+    /**
+     * Returns true if the given function selector is on the global blacklist, else false
+     * @param selector the selector to check
+     * @return true if blacklisted, else false
+     */
+    function isBlacklisted(bytes4 selector) internal pure returns (bool) {
+        return
+            selector == ERC20_TRANSFER ||
+            selector == ERC20_ERC721_APPROVE ||
+            selector == ERC20_ERC721_TRANSFER_FROM ||
+            selector == ERC721_SAFE_TRANSFER_FROM ||
+            selector == ERC721_SAFE_TRANSFER_FROM_DATA ||
+            selector == ERC721_ERC1155_SET_APPROVAL ||
+            selector == ERC1155_SAFE_TRANSFER_FROM ||
+            selector == ERC1155_SAFE_BATCH_TRANSFER_FROM;
+    }
+}

--- a/contracts/vault/VaultFactory.sol
+++ b/contracts/vault/VaultFactory.sol
@@ -17,10 +17,15 @@ import "../ERC721Permit.sol";
  */
 contract VaultFactory is ERC721Enumerable, ERC721Permit, IVaultFactory {
     address public immutable template;
+    address public immutable whitelist;
 
-    constructor(address _template) ERC721("Asset Wrapper V2", "AW-V2") ERC721Permit("Asset Wrapper V2") {
+    constructor(address _template, address _whitelist)
+        ERC721("Asset Wrapper V2", "AW-V2")
+        ERC721Permit("Asset Wrapper V2")
+    {
         require(_template != address(0), "VaultFactory: invalid template");
         template = _template;
+        whitelist = _whitelist;
     }
 
     /**
@@ -64,12 +69,13 @@ contract VaultFactory is ERC721Enumerable, ERC721Permit, IVaultFactory {
      */
     function _create() internal returns (address vault) {
         vault = Clones.clone(template);
-        IAssetVault(vault).initialize();
+        IAssetVault(vault).initialize(whitelist);
         return vault;
     }
 
     /**
      * @dev Hook that is called before any token transfer
+     * @dev note this notifies the vault contract about the ownership transfer
      */
     function _beforeTokenTransfer(
         address from,

--- a/test/CallWhitelist.ts
+++ b/test/CallWhitelist.ts
@@ -1,0 +1,260 @@
+import { expect } from "chai";
+import hre, { waffle } from "hardhat";
+const { loadFixture } = waffle;
+import { SignerWithAddress } from "@nomiclabs/hardhat-ethers/dist/src/signer-with-address";
+
+import { CallWhitelist, MockERC20, MockERC721, MockERC1155 } from "../typechain";
+import { deploy } from "./utils/contracts";
+
+type Signer = SignerWithAddress;
+
+interface TestContext {
+    whitelist: CallWhitelist;
+    mockERC20: MockERC20;
+    mockERC721: MockERC721;
+    mockERC1155: MockERC1155;
+    user: Signer;
+    other: Signer;
+    signers: Signer[];
+}
+
+describe("CallWhitelist", () => {
+    /**
+     * Sets up a test context, deploying new contracts and returning them for use in a test
+     */
+    const fixture = async (): Promise<TestContext> => {
+        const signers: Signer[] = await hre.ethers.getSigners();
+        const whitelist = <CallWhitelist>await deploy("CallWhitelist", signers[0], []);
+        const mockERC20 = <MockERC20>await deploy("MockERC20", signers[0], ["Mock ERC20", "MOCK"]);
+        const mockERC721 = <MockERC721>await deploy("MockERC721", signers[0], ["Mock ERC721", "MOCK"]);
+        const mockERC1155 = <MockERC1155>await deploy("MockERC1155", signers[0], []);
+
+        return {
+            whitelist,
+            mockERC20,
+            mockERC721,
+            mockERC1155,
+            user: signers[0],
+            other: signers[1],
+            signers: signers.slice(2),
+        };
+    };
+
+    describe("Access control", function () {
+        describe("add", async () => {
+            it("should succeed from owner", async () => {
+                const { whitelist, mockERC20, user } = await loadFixture(fixture);
+
+                const selector = mockERC20.interface.getSighash("mint");
+                await expect(whitelist.connect(user).add(mockERC20.address, selector))
+                    .to.emit(whitelist, "CallAdded")
+                    .withArgs(await user.getAddress(), mockERC20.address, selector);
+            });
+
+            it("should fail from non-owner", async () => {
+                const { whitelist, mockERC20, other } = await loadFixture(fixture);
+
+                const selector = mockERC20.interface.getSighash("mint");
+                await expect(whitelist.connect(other).add(mockERC20.address, selector)).to.be.revertedWith(
+                    "Ownable: caller is not the owner",
+                );
+            });
+
+            it("should succeed after ownership transferred", async () => {
+                const { whitelist, mockERC20, user, other } = await loadFixture(fixture);
+
+                const selector = mockERC20.interface.getSighash("mint");
+                await expect(whitelist.connect(user).transferOwnership(await other.getAddress()))
+                    .to.emit(whitelist, "OwnershipTransferred")
+                    .withArgs(await user.getAddress(), await other.getAddress());
+                await expect(whitelist.connect(other).add(mockERC20.address, selector))
+                    .to.emit(whitelist, "CallAdded")
+                    .withArgs(await other.getAddress(), mockERC20.address, selector);
+            });
+
+            it("should fail from old address after ownership transferred", async () => {
+                const { whitelist, mockERC20, user, other } = await loadFixture(fixture);
+
+                const selector = mockERC20.interface.getSighash("mint");
+                await expect(whitelist.connect(user).transferOwnership(await other.getAddress()))
+                    .to.emit(whitelist, "OwnershipTransferred")
+                    .withArgs(await user.getAddress(), await other.getAddress());
+                await expect(whitelist.connect(user).add(mockERC20.address, selector)).to.be.revertedWith(
+                    "Ownable: caller is not the owner",
+                );
+            });
+        });
+
+        describe("remove", async () => {
+            it("should succeed from owner", async () => {
+                const { whitelist, mockERC20, user } = await loadFixture(fixture);
+
+                const selector = mockERC20.interface.getSighash("mint");
+                await expect(whitelist.connect(user).add(mockERC20.address, selector))
+                    .to.emit(whitelist, "CallAdded")
+                    .withArgs(await user.getAddress(), mockERC20.address, selector);
+                await expect(whitelist.connect(user).remove(mockERC20.address, selector))
+                    .to.emit(whitelist, "CallRemoved")
+                    .withArgs(await user.getAddress(), mockERC20.address, selector);
+            });
+
+            it("should fail from non-owner", async () => {
+                const { whitelist, mockERC20, user, other } = await loadFixture(fixture);
+
+                const selector = mockERC20.interface.getSighash("mint");
+                await expect(whitelist.connect(user).add(mockERC20.address, selector))
+                    .to.emit(whitelist, "CallAdded")
+                    .withArgs(await user.getAddress(), mockERC20.address, selector);
+                await expect(whitelist.connect(other).remove(mockERC20.address, selector)).to.be.revertedWith(
+                    "Ownable: caller is not the owner",
+                );
+            });
+
+            it("should succeed after ownership transferred", async () => {
+                const { whitelist, mockERC20, user, other } = await loadFixture(fixture);
+
+                const selector = mockERC20.interface.getSighash("mint");
+                await expect(whitelist.connect(user).transferOwnership(await other.getAddress()))
+                    .to.emit(whitelist, "OwnershipTransferred")
+                    .withArgs(await user.getAddress(), await other.getAddress());
+                await expect(whitelist.connect(other).add(mockERC20.address, selector))
+                    .to.emit(whitelist, "CallAdded")
+                    .withArgs(await other.getAddress(), mockERC20.address, selector);
+                await expect(whitelist.connect(other).remove(mockERC20.address, selector))
+                    .to.emit(whitelist, "CallRemoved")
+                    .withArgs(await other.getAddress(), mockERC20.address, selector);
+            });
+
+            it("should fail from old address after ownership transferred", async () => {
+                const { whitelist, mockERC20, user, other } = await loadFixture(fixture);
+
+                const selector = mockERC20.interface.getSighash("mint");
+                await expect(whitelist.connect(user).transferOwnership(await other.getAddress()))
+                    .to.emit(whitelist, "OwnershipTransferred")
+                    .withArgs(await user.getAddress(), await other.getAddress());
+                await expect(whitelist.connect(other).add(mockERC20.address, selector))
+                    .to.emit(whitelist, "CallAdded")
+                    .withArgs(await other.getAddress(), mockERC20.address, selector);
+                await expect(whitelist.connect(user).remove(mockERC20.address, selector)).to.be.revertedWith(
+                    "Ownable: caller is not the owner",
+                );
+            });
+        });
+    });
+
+    describe("Global blacklist", function () {
+        it("erc20 transfer", async () => {
+            const { whitelist, mockERC20 } = await loadFixture(fixture);
+            const selector = mockERC20.interface.getSighash("transfer");
+            expect(await whitelist.isWhitelisted(mockERC20.address, selector)).to.be.false;
+        });
+
+        it("erc20 approve", async () => {
+            const { whitelist, mockERC20 } = await loadFixture(fixture);
+            const selector = mockERC20.interface.getSighash("approve");
+            expect(await whitelist.isWhitelisted(mockERC20.address, selector)).to.be.false;
+        });
+
+        it("erc20 transferFrom", async () => {
+            const { whitelist, mockERC20 } = await loadFixture(fixture);
+            const selector = mockERC20.interface.getSighash("transferFrom");
+            expect(await whitelist.isWhitelisted(mockERC20.address, selector)).to.be.false;
+        });
+
+        it("erc721 transferFrom", async () => {
+            const { whitelist, mockERC721 } = await loadFixture(fixture);
+            const selector = mockERC721.interface.getSighash("transferFrom");
+            expect(await whitelist.isWhitelisted(mockERC721.address, selector)).to.be.false;
+        });
+
+        it("erc721 safeTransferFrom", async () => {
+            const { whitelist, mockERC721 } = await loadFixture(fixture);
+            const selector = mockERC721.interface.getSighash("safeTransferFrom(address,address,uint256)");
+            expect(await whitelist.isWhitelisted(mockERC721.address, selector)).to.be.false;
+        });
+
+        it("erc721 safeTransferFrom with data", async () => {
+            const { whitelist, mockERC721 } = await loadFixture(fixture);
+            const selector = mockERC721.interface.getSighash("safeTransferFrom(address,address,uint256,bytes)");
+            expect(await whitelist.isWhitelisted(mockERC721.address, selector)).to.be.false;
+        });
+
+        it("erc721 setApprovalForAll", async () => {
+            const { whitelist, mockERC721 } = await loadFixture(fixture);
+            const selector = mockERC721.interface.getSighash("setApprovalForAll");
+            expect(await whitelist.isWhitelisted(mockERC721.address, selector)).to.be.false;
+        });
+
+        it("erc1155 setApprovalForAll", async () => {
+            const { whitelist, mockERC1155 } = await loadFixture(fixture);
+            const selector = mockERC1155.interface.getSighash("setApprovalForAll");
+            expect(await whitelist.isWhitelisted(mockERC1155.address, selector)).to.be.false;
+        });
+
+        it("erc1155 safeTransferFrom", async () => {
+            const { whitelist, mockERC1155 } = await loadFixture(fixture);
+            const selector = mockERC1155.interface.getSighash("safeTransferFrom");
+            expect(await whitelist.isWhitelisted(mockERC1155.address, selector)).to.be.false;
+        });
+
+        it("erc1155 safeBatchTransferFrom", async () => {
+            const { whitelist, mockERC1155 } = await loadFixture(fixture);
+            const selector = mockERC1155.interface.getSighash("safeBatchTransferFrom");
+            expect(await whitelist.isWhitelisted(mockERC1155.address, selector)).to.be.false;
+        });
+    });
+
+    describe("Whitelist", function () {
+        it("doesn't override global blacklist", async () => {
+            const { whitelist, mockERC20 } = await loadFixture(fixture);
+            const selector = mockERC20.interface.getSighash("transfer");
+
+            await whitelist.add(mockERC20.address, selector);
+            expect(await whitelist.isWhitelisted(mockERC20.address, selector)).to.be.false;
+        });
+
+        it("passes after adding to whitelist", async () => {
+            const { whitelist, mockERC20 } = await loadFixture(fixture);
+            const selector = mockERC20.interface.getSighash("mint");
+
+            expect(await whitelist.isWhitelisted(mockERC20.address, selector)).to.be.false;
+            await whitelist.add(mockERC20.address, selector);
+            expect(await whitelist.isWhitelisted(mockERC20.address, selector)).to.be.true;
+        });
+
+        it("fails after removing to whitelist", async () => {
+            const { whitelist, mockERC20 } = await loadFixture(fixture);
+            const selector = mockERC20.interface.getSighash("mint");
+
+            expect(await whitelist.isWhitelisted(mockERC20.address, selector)).to.be.false;
+            await whitelist.add(mockERC20.address, selector);
+            expect(await whitelist.isWhitelisted(mockERC20.address, selector)).to.be.true;
+            await whitelist.remove(mockERC20.address, selector);
+            expect(await whitelist.isWhitelisted(mockERC20.address, selector)).to.be.false;
+        });
+
+        it("adding twice is a noop", async () => {
+            const { whitelist, mockERC20 } = await loadFixture(fixture);
+            const selector = mockERC20.interface.getSighash("mint");
+
+            expect(await whitelist.isWhitelisted(mockERC20.address, selector)).to.be.false;
+            await whitelist.add(mockERC20.address, selector);
+            expect(await whitelist.isWhitelisted(mockERC20.address, selector)).to.be.true;
+            await whitelist.add(mockERC20.address, selector);
+            expect(await whitelist.isWhitelisted(mockERC20.address, selector)).to.be.true;
+        });
+
+        it("removing twice is a noop", async () => {
+            const { whitelist, mockERC20 } = await loadFixture(fixture);
+            const selector = mockERC20.interface.getSighash("mint");
+
+            expect(await whitelist.isWhitelisted(mockERC20.address, selector)).to.be.false;
+            await whitelist.add(mockERC20.address, selector);
+            expect(await whitelist.isWhitelisted(mockERC20.address, selector)).to.be.true;
+            await whitelist.remove(mockERC20.address, selector);
+            expect(await whitelist.isWhitelisted(mockERC20.address, selector)).to.be.false;
+            await whitelist.remove(mockERC20.address, selector);
+            expect(await whitelist.isWhitelisted(mockERC20.address, selector)).to.be.false;
+        });
+    });
+});

--- a/test/LoanCore.ts
+++ b/test/LoanCore.ts
@@ -214,7 +214,7 @@ describe("LoanCore", () => {
             const tx = await loanCore.connect(user).createLoan(terms);
             const receipt = await tx.wait();
             const gasUsed = receipt.gasUsed;
-            expect(gasUsed.toString()).to.equal("197218");
+            expect(gasUsed.toString()).to.equal("217380");
         });
     });
 
@@ -639,7 +639,7 @@ describe("LoanCore", () => {
                 .startLoan(await lender.getAddress(), await borrower.getAddress(), loanId);
             const receipt = await tx.wait();
             const gasUsed = receipt.gasUsed;
-            expect(gasUsed.toString()).to.equal("493400");
+            expect(gasUsed.toString()).to.equal("511256");
         });
     });
 
@@ -792,7 +792,7 @@ describe("LoanCore", () => {
             const tx = await loanCore.connect(borrower).repay(loanId);
             const receipt = await tx.wait();
             const gasUsed = receipt.gasUsed;
-            expect(gasUsed.toString()).to.equal("207190");
+            expect(gasUsed.toString()).to.equal("225315");
         });
     });
 
@@ -960,7 +960,7 @@ describe("LoanCore", () => {
             const tx = await loanCore.connect(borrower).claim(loanId);
             const receipt = await tx.wait();
             const gasUsed = receipt.gasUsed;
-            expect(gasUsed.toString()).to.equal("167268");
+            expect(gasUsed.toString()).to.equal("185445");
         });
     });
 
@@ -1092,6 +1092,156 @@ describe("LoanCore", () => {
                     await borrower.getAddress()
                 ).toLowerCase()} is missing role ${CLAIM_FEES_ROLE}`,
             );
+        });
+    });
+
+    describe("canCallOn", function () {
+        interface StartLoanState extends TestContext {
+            loanId: BigNumber;
+            terms: LoanTerms;
+            borrower: Signer;
+            lender: Signer;
+        }
+
+        const setupLoan = async (): Promise<StartLoanState> => {
+            const context = await loadFixture(fixture);
+
+            const { mockAssetWrapper, mockERC20, loanCore, user: borrower, other: lender } = context;
+            const collateralTokenId = await mintERC721(mockAssetWrapper, borrower);
+            const terms = createLoanTerms(mockERC20.address, { collateralTokenId });
+            const loanId = await createLoan(loanCore, borrower, terms);
+            return { ...context, loanId, terms, borrower, lender };
+        };
+
+        it("should return true for borrower on vault in use as collateral", async () => {
+            const {
+                mockAssetWrapper,
+                loanCore,
+                mockERC20,
+                loanId,
+                terms: { collateralTokenId, principal },
+                borrower,
+                lender,
+            } = await setupLoan();
+            await mockAssetWrapper
+                .connect(borrower)
+                .transferFrom(await borrower.getAddress(), await borrower.getAddress(), collateralTokenId);
+            await mockAssetWrapper.connect(borrower).approve(loanCore.address, collateralTokenId);
+
+            await mockERC20.connect(lender).mint(await lender.getAddress(), principal);
+            await mockERC20.connect(lender).transfer(await borrower.getAddress(), principal);
+            await mockERC20.connect(borrower).approve(loanCore.address, principal);
+
+            await expect(
+                loanCore.connect(borrower).startLoan(await lender.getAddress(), await borrower.getAddress(), loanId),
+            )
+                .to.emit(loanCore, "LoanStarted")
+                .withArgs(loanId, await lender.getAddress(), await borrower.getAddress());
+            expect(await loanCore.canCallOn(await borrower.getAddress(), collateralTokenId.toHexString())).to.be.true;
+        });
+
+        it("should return true for any vaults if borrower has several", async () => {
+            const context = await loadFixture(fixture);
+
+            const { mockAssetWrapper, mockERC20, loanCore, user: borrower, other: lender } = context;
+            const collateralTokenId = await mintERC721(mockAssetWrapper, borrower);
+            const terms = createLoanTerms(mockERC20.address, { collateralTokenId });
+            const loanId = await createLoan(loanCore, borrower, terms);
+
+            await mockAssetWrapper
+                .connect(borrower)
+                .transferFrom(await borrower.getAddress(), await borrower.getAddress(), collateralTokenId);
+            await mockAssetWrapper.connect(borrower).approve(loanCore.address, collateralTokenId);
+            await mockERC20.connect(lender).mint(await lender.getAddress(), terms.principal);
+            await mockERC20.connect(lender).transfer(await borrower.getAddress(), terms.principal);
+            await mockERC20.connect(borrower).approve(loanCore.address, terms.principal);
+            await loanCore.connect(borrower).startLoan(await lender.getAddress(), await borrower.getAddress(), loanId);
+
+            const collateralTokenId2 = await mintERC721(mockAssetWrapper, borrower);
+            const terms2 = createLoanTerms(mockERC20.address, { collateralTokenId: collateralTokenId2 });
+            const loanId2 = await createLoan(loanCore, borrower, terms2);
+
+            await mockAssetWrapper
+                .connect(borrower)
+                .transferFrom(await borrower.getAddress(), await borrower.getAddress(), collateralTokenId2);
+            await mockAssetWrapper.connect(borrower).approve(loanCore.address, collateralTokenId2);
+            await mockERC20.connect(lender).mint(await lender.getAddress(), terms2.principal);
+            await mockERC20.connect(lender).transfer(await borrower.getAddress(), terms2.principal);
+            await mockERC20.connect(borrower).approve(loanCore.address, terms2.principal);
+            await loanCore.connect(borrower).startLoan(await lender.getAddress(), await borrower.getAddress(), loanId2);
+
+            expect(await loanCore.canCallOn(await borrower.getAddress(), collateralTokenId.toHexString())).to.be.true;
+            expect(await loanCore.canCallOn(await borrower.getAddress(), collateralTokenId2.toHexString())).to.be.true;
+        });
+
+        it("should return false if loan is created but not started", async () => {
+            const {
+                loanCore,
+                borrower,
+                terms: { collateralTokenId },
+            } = await setupLoan();
+            expect(await loanCore.canCallOn(await borrower.getAddress(), collateralTokenId.toHexString())).to.be.false;
+        });
+
+        it("should return false for irrelevant user and vault", async () => {
+            const { loanCore, signers } = await setupLoan();
+            expect(await loanCore.canCallOn(await signers[2].getAddress(), await signers[3].getAddress())).to.be.false;
+        });
+
+        it("should return false for irrelevant user on vault in use as collateral", async () => {
+            const {
+                mockAssetWrapper,
+                loanCore,
+                mockERC20,
+                loanId,
+                terms: { collateralTokenId, principal },
+                borrower,
+                lender,
+                signers,
+            } = await setupLoan();
+            await mockAssetWrapper
+                .connect(borrower)
+                .transferFrom(await borrower.getAddress(), await borrower.getAddress(), collateralTokenId);
+            await mockAssetWrapper.connect(borrower).approve(loanCore.address, collateralTokenId);
+
+            await mockERC20.connect(lender).mint(await lender.getAddress(), principal);
+            await mockERC20.connect(lender).transfer(await borrower.getAddress(), principal);
+            await mockERC20.connect(borrower).approve(loanCore.address, principal);
+
+            await expect(
+                loanCore.connect(borrower).startLoan(await lender.getAddress(), await borrower.getAddress(), loanId),
+            )
+                .to.emit(loanCore, "LoanStarted")
+                .withArgs(loanId, await lender.getAddress(), await borrower.getAddress());
+            expect(await loanCore.canCallOn(await signers[2].getAddress(), collateralTokenId.toHexString())).to.be
+                .false;
+        });
+
+        it("should return false for lender user on vault in use as collateral", async () => {
+            const {
+                mockAssetWrapper,
+                loanCore,
+                mockERC20,
+                loanId,
+                terms: { collateralTokenId, principal },
+                borrower,
+                lender,
+            } = await setupLoan();
+            await mockAssetWrapper
+                .connect(borrower)
+                .transferFrom(await borrower.getAddress(), await borrower.getAddress(), collateralTokenId);
+            await mockAssetWrapper.connect(borrower).approve(loanCore.address, collateralTokenId);
+
+            await mockERC20.connect(lender).mint(await lender.getAddress(), principal);
+            await mockERC20.connect(lender).transfer(await borrower.getAddress(), principal);
+            await mockERC20.connect(borrower).approve(loanCore.address, principal);
+
+            await expect(
+                loanCore.connect(borrower).startLoan(await lender.getAddress(), await borrower.getAddress(), loanId),
+            )
+                .to.emit(loanCore, "LoanStarted")
+                .withArgs(loanId, await lender.getAddress(), await borrower.getAddress());
+            expect(await loanCore.canCallOn(await lender.getAddress(), collateralTokenId.toHexString())).to.be.false;
         });
     });
 });

--- a/test/VaultFactory.ts
+++ b/test/VaultFactory.ts
@@ -6,7 +6,7 @@ import { BigNumber, BigNumberish } from "ethers";
 import { fromRpcSig } from "ethereumjs-util";
 
 import { ZERO_ADDRESS } from "./utils/erc20";
-import { AssetVault, VaultFactory } from "../typechain";
+import { CallWhitelist, AssetVault, VaultFactory } from "../typechain";
 import { deploy } from "./utils/contracts";
 
 type Signer = SignerWithAddress;
@@ -25,8 +25,11 @@ describe("VaultFactory", () => {
      */
     const fixture = async (): Promise<TestContext> => {
         const signers: Signer[] = await hre.ethers.getSigners();
+        const whitelist = <CallWhitelist>await deploy("CallWhitelist", signers[0], []);
         const vaultTemplate = <AssetVault>await deploy("AssetVault", signers[0], []);
-        const factory = <VaultFactory>await deploy("VaultFactory", signers[0], [vaultTemplate.address]);
+        const factory = <VaultFactory>(
+            await deploy("VaultFactory", signers[0], [vaultTemplate.address, whitelist.address])
+        );
 
         return {
             factory,


### PR DESCRIPTION
This commit adds the claim functionality to the AssetVault.

This allows someone to call an arbitrary function from the
vault's context (i.e. claim(token)).

The user who can call functions on behalf if the vault is one of the
following:
- the current owner of the contract
- an address that the current owner of the contract explicitly delegates
call ability to (i.e. LoanCore delegates it to the borrower of the
relevant loan).

It uses a whitelist contract to protect the lender and any
system holding a vault NFT as collateral from
having the underlying collateral sneakily removed.

The whitelist contract is a singleton admin contract which has two main
components:
- a dynamic whitelist where the admin can add (contract address,
function selector) pairs that are allowed to be called
- a global blacklist of functions that can never be called in any
context (i.e. token transfers for removal from the vault)